### PR TITLE
chore(test): rename DatastoreTest to ITDatastoreTest

### DIFF
--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/ITDatastoreTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/ITDatastoreTest.java
@@ -73,7 +73,7 @@ import org.junit.runners.JUnit4;
 import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
-public class DatastoreTest {
+public class ITDatastoreTest {
 
   private static LocalDatastoreHelper helper = LocalDatastoreHelper.create(1.0);
   private static final DatastoreOptions options = helper.getOptions();

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/ITLocalDatastoreHelperTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/ITLocalDatastoreHelperTest.java
@@ -39,7 +39,7 @@ import org.junit.runners.JUnit4;
 import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
-public class LocalDatastoreHelperTest {
+public class ITLocalDatastoreHelperTest {
 
   private static final double TOLERANCE = 0.00001;
   private static final String PROJECT_ID_PREFIX = "test-project-";


### PR DESCRIPTION
Integration tests are not ran on OS X CI builds, moving DatastoreTest &
LocalDatastoreHelperTest to work around the fact that the emulator is
accessible on kokoro nodes.