### PR TITLE
fix: bom version tag miss configured

### DIFF
--- a/google-cloud-datastore-bom/pom.xml
+++ b/google-cloud-datastore-bom/pom.xml
@@ -68,7 +68,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-datastore</artifactId>
-        <version>0.85.2-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-datastore-v1:current} -->
+        <version>1.102.2-SNAPSHOT</version><!-- {x-version-update:google-cloud-datastore:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
The bom had been miss configured to change the version of google-cloud-datastore to be the version for proto-google-cloud-datastore-v1 this change fixes the marker and the version.
