### PR TITLE
fix: update retry logic for operations that can be associated with a transaction

### DIFF
--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
@@ -51,6 +51,8 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
   private final RetrySettings retrySettings;
   private static final ExceptionHandler TRANSACTION_EXCEPTION_HANDLER =
       TransactionExceptionHandler.build();
+  private static final ExceptionHandler TRANSACTION_OPERATION_EXCEPTION_HANDLER =
+      TransactionOperationExceptionHandler.build();
 
   DatastoreImpl(DatastoreOptions options) {
     super(options);
@@ -182,7 +184,9 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
             }
           },
           retrySettings,
-          EXCEPTION_HANDLER,
+          requestPb.getReadOptions().getTransaction().isEmpty()
+              ? EXCEPTION_HANDLER
+              : TRANSACTION_OPERATION_EXCEPTION_HANDLER,
           getOptions().getClock());
     } catch (RetryHelperException e) {
       throw DatastoreException.translateAndThrow(e);
@@ -394,7 +398,9 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
             }
           },
           retrySettings,
-          EXCEPTION_HANDLER,
+          requestPb.getReadOptions().getTransaction().isEmpty()
+              ? EXCEPTION_HANDLER
+              : TRANSACTION_OPERATION_EXCEPTION_HANDLER,
           getOptions().getClock());
     } catch (RetryHelperException e) {
       throw DatastoreException.translateAndThrow(e);
@@ -532,7 +538,9 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
             }
           },
           retrySettings,
-          EXCEPTION_HANDLER,
+          requestPb.getTransaction().isEmpty()
+              ? EXCEPTION_HANDLER
+              : TRANSACTION_OPERATION_EXCEPTION_HANDLER,
           getOptions().getClock());
     } catch (RetryHelperException e) {
       throw DatastoreException.translateAndThrow(e);

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/TransactionOperationExceptionHandler.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/TransactionOperationExceptionHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.datastore;
+
+import com.google.api.core.BetaApi;
+import com.google.cloud.BaseService;
+import com.google.cloud.ExceptionHandler;
+import com.google.cloud.ExceptionHandler.Interceptor;
+
+@BetaApi
+public class TransactionOperationExceptionHandler {
+
+  public static final Interceptor TRANSACTION_OPERATION_EXCEPTION_HANDLER_INTERCEPTOR =
+      new Interceptor() {
+
+        private static final long serialVersionUID = -1240723093072535978L;
+
+        private static final int ABORTED_CODE = 10;
+
+        @Override
+        public RetryResult beforeEval(Exception exception) {
+          if (exception instanceof DatastoreException) {
+            DatastoreException e = getInnerException((DatastoreException) exception);
+            if (e.getCode() == ABORTED_CODE
+                || e.getReason() != null && e.getReason().equals("ABORTED")) {
+              return RetryResult.NO_RETRY;
+            }
+          }
+          return BaseService.EXCEPTION_HANDLER_INTERCEPTOR.beforeEval(exception);
+        }
+
+        @Override
+        public RetryResult afterEval(Exception exception, RetryResult retryResult) {
+          return BaseService.EXCEPTION_HANDLER_INTERCEPTOR.afterEval(exception, retryResult);
+        }
+
+        private DatastoreException getInnerException(DatastoreException exception) {
+          while (exception.getCause() instanceof DatastoreException) {
+            exception = (DatastoreException) exception.getCause();
+          }
+          return exception;
+        }
+      };
+
+  public static ExceptionHandler build() {
+    return ExceptionHandler.newBuilder()
+        .abortOn(RuntimeException.class)
+        .addInterceptors(TRANSACTION_OPERATION_EXCEPTION_HANDLER_INTERCEPTOR)
+        .build();
+  }
+
+  /** Intentionally private empty constructor to disable instantiation of this class. */
+  private TransactionOperationExceptionHandler() {}
+}


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-datastore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes b/157596445 ☕️

Add a new exception handler for requests that may run within a transaction. The handler prevents retries on ABORTED error, since an aborted transaction cannot be re-used.