### PR TITLE
chore: regenerate CODEOWNERS from templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,8 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
+# The @googleapis/firestore-dpe is the default owner for changes in this repo
+**/*.java               @googleapis/firestore-dpe
+
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,5 +9,6 @@
   "repo": "googleapis/java-datastore",
   "repo_short": "java-datastore",
   "distribution_name": "com.google.cloud:google-cloud-datastore",
+  "codeowner_team": "@googleapis/firestore-dpe",
   "api_id": "datastore.googleapis.com"
 }

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,23 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/java-datastore.git",
-        "sha": "4de5241268ee97a88bd6a066db97177b8b7f5b07"
+        "remote": "git@github.com:BenWhitehead/java-datastore.git",
+        "sha": "d0b86f4ef69f52925a5670385e494177e841cef2"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "c829fa0bfa725adaf20d82e86cbc1220e3ffd784",
-        "internalRef": "316124477"
+        "sha": "99ae9a76dbecb2aab008d5403e25413f5da0f436",
+        "internalRef": "320455075"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "4f2c9f752a94042472fc03c5bd9e06e89817d2bd"
+        "sha": "799d8e6522c1ef7cb55a70d9ea0b15e045c3d00b"
       }
     }
   ],


### PR DESCRIPTION
CODEOWNERS is now managed by templates and we can configure the default team in the .repo-metadata.json file.