### PR TITLE
deps: remove direct declaration of google-auth-library-oauth2-http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,11 +181,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.google.auth</groupId>
-        <artifactId>google-auth-library-oauth2-http</artifactId>
-        <version>0.20.0</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.oauth-client</groupId>
         <artifactId>google-oauth-client</artifactId>
         <version>1.30.6</version>


### PR DESCRIPTION
Rather than having a direct managed dependency for
google-auth-library-oauth2-http use the version provided by
google-cloud-shared-dependencies.
