### PR TITLE
deps: update google-cloud-shared-dependencies to 0.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>0.13.0</version>
+        <version>0.15.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
to address Data Fusion customer issue where they need compatibility for datastore, bigquery, pubsub, storage, texttospeech, and bigtable client libraries.