### PR TITLE
deps: update shared dependencies to 2.7.0 and remove google-oauth-client from dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -170,11 +170,6 @@
             <artifactId>proto-google-cloud-datastore-v1</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.google.oauth-client</groupId>
-        <artifactId>google-oauth-client</artifactId>
-        <version>1.32.1</version>
       </dependency>
       <!-- Test dependencies -->
       <dependency>


### PR DESCRIPTION
It is managed in the shared dependencies BOM
