### PR TITLE
fix: Use ImmutableMap.Builder.buildOrThrow() instead of build().

### DIFF
--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/GqlQuery.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/GqlQuery.java
@@ -449,7 +449,7 @@ public final class GqlQuery<V> extends Query<V> {
     for (Map.Entry<String, Binding> binding : namedBindings.entrySet()) {
       builder.put(binding.getKey(), binding.getValue().getCursorOrValue());
     }
-    return builder.build();
+    return builder.buildOrThrow();
   }
 
   /** Returns an immutable list of positional bindings (using original order). */

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/ReadOption.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/ReadOption.java
@@ -62,6 +62,6 @@ public abstract class ReadOption implements Serializable {
     for (ReadOption option : options) {
       builder.put(option.getClass(), option);
     }
-    return builder.build();
+    return builder.buildOrThrow();
   }
 }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/ValueType.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/ValueType.java
@@ -76,7 +76,7 @@ public enum ValueType {
         builder.put(fieldId, valueType);
       }
     }
-    DESCRIPTOR_TO_TYPE_MAP = builder.build();
+    DESCRIPTOR_TO_TYPE_MAP = builder.buildOrThrow();
   }
 
   <V, P extends Value<V>, B extends ValueBuilder<V, P, B>> ValueType(

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/ValueTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/ValueTest.java
@@ -58,7 +58,7 @@ public class ValueTest {
           .put(ValueType.RAW_VALUE, new Object[] {RawValue.class, RAW_VALUE.get()})
           .put(ValueType.LAT_LNG, new Object[] {LatLngValue.class, LAT_LNG_VALUE.get()})
           .put(ValueType.STRING, new Object[] {StringValue.class, STRING_VALUE.get()})
-          .build();
+          .buildOrThrow();
 
   private ImmutableMap<ValueType, Value<?>> typeToValue;
 
@@ -110,7 +110,7 @@ public class ValueTest {
         assertTrue("Could not find an of method for " + valueClass, found);
       }
     }
-    typeToValue = builder.build();
+    typeToValue = builder.buildOrThrow();
   }
 
   @Test


### PR DESCRIPTION
ImmutableMap.Builder.build() recommends usage of buildOrThrow() instead.