### PR TITLE
docs(sample): Use Java 8 for Native Image sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:24.3.0')
+implementation platform('com.google.cloud:libraries-bom:24.4.0')
 
 implementation 'com.google.cloud:google-cloud-datastore'
 ```

--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -17,8 +17,9 @@
   </parent>
 
   <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <!-- Java 8 because the Kokoro Sample test uses that Java version -->
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -63,8 +63,7 @@
         <configuration>
           <archive>
             <manifest>
-              <mainClass>com.example.datastore.NativeImageDatastoreSample
-              </mainClass>
+              <mainClass>com.example.datastore.NativeImageDatastoreSample</mainClass>
             </manifest>
           </archive>
         </configuration>
@@ -116,8 +115,7 @@
             <version>0.9.10</version>
             <extensions>true</extensions>
             <configuration>
-              <mainClass>com.example.datastore.NativeImageDatastoreSample
-              </mainClass>
+              <mainClass>com.example.datastore.NativeImageDatastoreSample</mainClass>
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>


### PR DESCRIPTION
This fixes the following failure in the nightly samples build:

![Screen Shot 2022-03-02 at 11 37 50 AM](https://user-images.githubusercontent.com/66699525/156406294-cef30122-6c18-4df6-a2ed-2a78ae968c05.png)

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
