### PR TITLE
chore: Change the Codeowner to cloud-native-db-dpes (#686)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,9 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/firestore-dpe is the default owner for changes in this repo
-*                       @googleapis/yoshi-java @googleapis/firestore-dpe
-**/*.java               @googleapis/firestore-dpe
+# The @googleapis/cloud-native-db-dpes @googleapis/api-firestore is the default owner for changes in this repo
+*                       @googleapis/yoshi-java @googleapis/cloud-native-db-dpes @googleapis/api-firestore
+**/*.java               @googleapis/cloud-native-db-dpes @googleapis/api-firestore
 
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,7 +9,7 @@
   "repo": "googleapis/java-datastore",
   "repo_short": "java-datastore",
   "distribution_name": "com.google.cloud:google-cloud-datastore",
-  "codeowner_team": "@googleapis/firestore-dpe",
+  "codeowner_team": "@googleapis/cloud-native-db-dpes @googleapis/api-firestore",
   "api_id": "datastore.googleapis.com",
   "library_type": "GAPIC_COMBO",
   "api_description": "is a fully managed, schemaless database for\nstoring non-relational data. Cloud Datastore automatically scales with\nyour users and supports ACID transactions, high availability of reads and\nwrites, strong consistency for reads and ancestor queries, and eventual\nconsistency for all other queries.",

--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:25.0.0')
+implementation platform('com.google.cloud:libraries-bom:25.1.0')
 
 implementation 'com.google.cloud:google-cloud-datastore'
 ```
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-datastore:2.2.8'
+implementation 'com.google.cloud:google-cloud-datastore:2.3.1'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.2.8"
+libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.3.1"
 ```
 
 ## Authentication


### PR DESCRIPTION
* chore: Change the Codeowner to cloud-native-db-dpes

* 🦉 Updates from OwlBot post-processor

See https://github.com/googleapis/repo-automation-bots/blob/main/packages/owl-bot/README.md

* Add api-firestore team

* Update CODEOWNERS

* 🦉 Updates from OwlBot post-processor

See https://github.com/googleapis/repo-automation-bots/blob/main/packages/owl-bot/README.md

* Add @googleapis/api-firestore to the codeowner

* 🦉 Updates from OwlBot post-processor

See https://github.com/googleapis/repo-automation-bots/blob/main/packages/owl-bot/README.md

Co-authored-by: Owl Bot <gcf-owl-bot[bot]@users.noreply.github.com>

cherry pick of #686 