### PR TITLE
samples: Add example snippet for snapshot reads

### DIFF
--- a/samples/snippets/src/test/java/com/google/datastore/snippets/ConceptsTest.java
+++ b/samples/snippets/src/test/java/com/google/datastore/snippets/ConceptsTest.java
@@ -1147,10 +1147,10 @@ public class ConceptsTest {
   }
 
   @Test
-  public void testSnapshotReads() {
+  public void testStaleReads() {
     setUpQueryTestsRealBackend();
     Datastore datastoreClient = datastoreRealBackend;
-    // [START datastore_snapshot_read]
+    // [START datastore_stale_read]
     Key taskKey =
         datastoreClient
             .newKeyFactory()
@@ -1158,20 +1158,18 @@ public class ConceptsTest {
             .addAncestors(PathElement.of("TaskList", "default"))
             .newKey("someTask");
 
-    // Create a timestamp for two minutes ago
-    Timestamp now = Timestamp.now();
-    Timestamp twoMinutesAgo =
-        Timestamp.ofTimeSecondsAndNanos(now.getSeconds() - 120L, now.getNanos());
-    // Create a readOption to read at time twoMinutesAgo
-    ReadOption readOption = ReadOption.readTime(twoMinutesAgo);
-    // Use readOption to Fetch entity at time twoMinutesAgo
+    Timestamp fifteenSecondsAgo =
+        Timestamp.ofTimeSecondsAndNanos(Timestamp.now().getSeconds() - 15L, 0);
+    // Create a readOption with read time fifteenSecondsAgo
+    ReadOption readOption = ReadOption.readTime(fifteenSecondsAgo);
+    // Use the readOption to Fetch entity
     Entity entity = datastoreClient.get(taskKey, readOption);
 
-    // Use readOption to Query kind Task at time twoMinutesAgo
+    // Use the readOption to Query kind Task
     Query<Entity> query = Query.newEntityQueryBuilder().setKind("Task").setLimit(10).build();
     QueryResults<Entity> results = datastoreClient.run(query, readOption);
     Entity result = results.next();
-    // [END datastore_snapshot_read]
+    // [END datastore_stale_read]
     assertValidQueryRealBackend(query);
   }
 }

--- a/samples/snippets/src/test/java/com/google/datastore/snippets/ConceptsTest.java
+++ b/samples/snippets/src/test/java/com/google/datastore/snippets/ConceptsTest.java
@@ -1161,7 +1161,7 @@ public class ConceptsTest {
     // Create a timestamp for two minutes ago
     Timestamp now = Timestamp.now();
     Timestamp twoMinutesAgo =
-        Timestamp.ofTimeSecondsAndNanos(now.getSeconds() - 120l, now.getNanos());
+        Timestamp.ofTimeSecondsAndNanos(now.getSeconds() - 120L, now.getNanos());
     // Create a readOption to read at time twoMinutesAgo
     ReadOption readOption = ReadOption.readTime(twoMinutesAgo);
     // Use readOption to Fetch entity at time twoMinutesAgo

--- a/samples/snippets/src/test/java/com/google/datastore/snippets/ConceptsTest.java
+++ b/samples/snippets/src/test/java/com/google/datastore/snippets/ConceptsTest.java
@@ -1145,4 +1145,33 @@ public class ConceptsTest {
     // [END datastore_in_query_sorted]
     assertValidQueryRealBackend(query);
   }
+
+  @Test
+  public void testSnapshotReads() {
+    setUpQueryTestsRealBackend();
+    Datastore datastoreClient = datastoreRealBackend;
+    // [START datastore_snapshot_read]
+    Key taskKey =
+        datastoreClient
+            .newKeyFactory()
+            .setKind("Task")
+            .addAncestors(PathElement.of("TaskList", "default"))
+            .newKey("someTask");
+
+    // Create a timestamp for two minutes ago
+    Timestamp now = Timestamp.now();
+    Timestamp twoMinutesAgo =
+        Timestamp.ofTimeSecondsAndNanos(now.getSeconds() - 120l, now.getNanos());
+    // Create a readOption to read at time twoMinutesAgo
+    ReadOption readOption = ReadOption.readTime(twoMinutesAgo);
+    // Use readOption to Fetch entity at time twoMinutesAgo
+    Entity entity = datastoreClient.get(taskKey, readOption);
+
+    // Use readOption to Query kind Task at time twoMinutesAgo
+    Query<Entity> query = Query.newEntityQueryBuilder().setKind("Task").setLimit(10).build();
+    QueryResults<Entity> results = datastoreClient.run(query, readOption);
+    Entity result = results.next();
+    // [END datastore_snapshot_read]
+    assertValidQueryRealBackend(query);
+  }
 }


### PR DESCRIPTION
Add a snippet that shows how to set a readTime in entity retrievals.

Fixes #808 ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
