### PR TITLE
refactor: making query class generic 

### DIFF
--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
@@ -180,8 +180,10 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
     return run(toReadOptionsPb(options), query);
   }
 
+  @SuppressWarnings("unchecked")
   <T> QueryResults<T> run(com.google.datastore.v1.ReadOptions readOptionsPb, Query<T> query) {
-    return new QueryResultsImpl<>(this, readOptionsPb, query);
+    return new QueryResultsImpl<>(
+        this, readOptionsPb, (RecordQuery<T>) query, query.getNamespace());
   }
 
   com.google.datastore.v1.RunQueryResponse runQuery(

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Query.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Query.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.datastore;
 
-
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.Maps;

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Query.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Query.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.datastore;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
@@ -39,7 +38,6 @@ public abstract class Query<V> implements Serializable {
 
   private static final long serialVersionUID = 7967659059395653941L;
 
-  private final ResultType<V> resultType;
   private final String namespace;
 
   /**
@@ -156,13 +154,8 @@ public abstract class Query<V> implements Serializable {
     }
   }
 
-  Query(ResultType<V> resultType, String namespace) {
-    this.resultType = checkNotNull(resultType);
+  Query(String namespace) {
     this.namespace = namespace;
-  }
-
-  ResultType<V> getType() {
-    return resultType;
   }
 
   public String getNamespace() {
@@ -170,12 +163,8 @@ public abstract class Query<V> implements Serializable {
   }
 
   ToStringHelper toStringHelper() {
-    return MoreObjects.toStringHelper(this).add("type", resultType).add("namespace", namespace);
+    return MoreObjects.toStringHelper(this).add("namespace", namespace);
   }
-
-  abstract void populatePb(com.google.datastore.v1.RunQueryRequest.Builder requestPb);
-
-  abstract Query<V> nextQuery(com.google.datastore.v1.RunQueryResponse responsePb);
 
   /**
    * Returns a new {@link GqlQuery} builder.

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/QueryResultsImpl.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/QueryResultsImpl.java
@@ -30,7 +30,7 @@ class QueryResultsImpl<T> extends AbstractIterator<T> implements QueryResults<T>
   private final com.google.datastore.v1.ReadOptions readOptionsPb;
   private final com.google.datastore.v1.PartitionId partitionIdPb;
   private final ResultType<T> queryResultType;
-  private Query<T> query;
+  private RecordQuery<T> query;
   private ResultType<?> actualResultType;
   private com.google.datastore.v1.RunQueryResponse runQueryResponsePb;
   private com.google.datastore.v1.Query mostRecentQueryPb;
@@ -40,7 +40,10 @@ class QueryResultsImpl<T> extends AbstractIterator<T> implements QueryResults<T>
   private MoreResultsType moreResults;
 
   QueryResultsImpl(
-      DatastoreImpl datastore, com.google.datastore.v1.ReadOptions readOptionsPb, Query<T> query) {
+      DatastoreImpl datastore,
+      com.google.datastore.v1.ReadOptions readOptionsPb,
+      RecordQuery<T> query,
+      String namespace) {
     this.datastore = datastore;
     this.readOptionsPb = readOptionsPb;
     this.query = query;
@@ -48,8 +51,8 @@ class QueryResultsImpl<T> extends AbstractIterator<T> implements QueryResults<T>
     com.google.datastore.v1.PartitionId.Builder pbBuilder =
         com.google.datastore.v1.PartitionId.newBuilder();
     pbBuilder.setProjectId(datastore.getOptions().getProjectId());
-    if (query.getNamespace() != null) {
-      pbBuilder.setNamespaceId(query.getNamespace());
+    if (namespace != null) {
+      pbBuilder.setNamespaceId(namespace);
     } else if (datastore.getOptions().getNamespace() != null) {
       pbBuilder.setNamespaceId(datastore.getOptions().getNamespace());
     }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/RecordQuery.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/RecordQuery.java
@@ -22,6 +22,7 @@ import com.google.cloud.datastore.Query.ResultType;
 @InternalApi
 public interface RecordQuery<V> {
 
+  @InternalApi
   ResultType<V> getType();
 
   @InternalApi

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/RecordQuery.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/RecordQuery.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.datastore;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.datastore.Query.ResultType;
+
+/** An internal marker interface to represent {@link Query} that returns the entity records. */
+@InternalApi
+public interface RecordQuery<V> {
+
+  ResultType<V> getType();
+
+  @InternalApi
+  void populatePb(com.google.datastore.v1.RunQueryRequest.Builder requestPb);
+
+  @InternalApi
+  RecordQuery<V> nextQuery(com.google.datastore.v1.RunQueryResponse responsePb);
+}

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreTest.java
@@ -613,7 +613,7 @@ public class DatastoreTest {
     Entity entity5 = Entity.newBuilder(KEY5).set("value", "value").build();
     datastore.add(ENTITY3, entity4, entity5);
     List<RunQueryResponse> responses = new ArrayList<>();
-    Query<Key> query = Query.newKeyQueryBuilder().build();
+    RecordQuery<Key> query = Query.newKeyQueryBuilder().build();
     RunQueryRequest.Builder requestPb = RunQueryRequest.newBuilder();
     query.populatePb(requestPb);
     QueryResultBatch queryResultBatchPb =
@@ -722,7 +722,7 @@ public class DatastoreTest {
     datastore.add(ENTITY3, entity4, entity5);
     DatastoreRpc datastoreRpc = datastore.getOptions().getDatastoreRpcV1();
     List<RunQueryResponse> responses = new ArrayList<>();
-    Query<Entity> query = Query.newEntityQueryBuilder().build();
+    RecordQuery<Entity> query = Query.newEntityQueryBuilder().build();
     RunQueryRequest.Builder requestPb = RunQueryRequest.newBuilder();
     query.populatePb(requestPb);
     QueryResultBatch queryResultBatchPb =


### PR DESCRIPTION
This change decouples Query.java from the concerns related to handling entity records. It is required as the definition of a Query is changed now and it is not just limited to the the fact that every query returns entity records, With the introduction of count feature and aggregation query, we will have queries returning aggregation results.


_Note: This PR is intended to trim down the changes done as part of #823._