### PR TITLE
fix: #355 Explicitly passing --project argument when starting emulator

### DIFF
--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -140,6 +140,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
         "datastore",
         builder.port > 0 ? builder.port : BaseEmulatorHelper.findAvailablePort(DEFAULT_PORT),
         firstNonNull(builder.projectId, DEFAULT_PROJECT_ID));
+    String projectId = firstNonNull(builder.projectId, DEFAULT_PROJECT_ID);
     this.consistency = builder.consistency > 0 ? builder.consistency : DEFAULT_CONSISTENCY;
     this.gcdPath = builder.dataDir;
     this.storeOnDisk = builder.storeOnDisk;
@@ -150,7 +151,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
     List<String> gcloudCommand = new ArrayList<>(Arrays.asList(GCLOUD_CMD_TEXT.split(" ")));
     gcloudCommand.add(GCLOUD_CMD_PORT_FLAG + "localhost:" + getPort());
     gcloudCommand.add(CONSISTENCY_FLAG + builder.consistency);
-    gcloudCommand.add(PROJECT_FLAG + getProjectId());
+    gcloudCommand.add(PROJECT_FLAG + projectId);
     if (!builder.storeOnDisk) {
       gcloudCommand.add("--no-store-on-disk");
     }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -68,6 +68,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
 
   // Common settings
   private static final String CONSISTENCY_FLAG = "--consistency=";
+  private static final String PROJECT_FLAG = "--project=";
   private static final double DEFAULT_CONSISTENCY = 0.9;
 
   private static final Logger LOGGER = Logger.getLogger(LocalDatastoreHelper.class.getName());
@@ -140,6 +141,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
     List<String> gcloudCommand = new ArrayList<>(Arrays.asList(GCLOUD_CMD_TEXT.split(" ")));
     gcloudCommand.add(GCLOUD_CMD_PORT_FLAG + "localhost:" + getPort());
     gcloudCommand.add(CONSISTENCY_FLAG + builder.consistency);
+    gcloudCommand.add(PROJECT_FLAG + getProjectId());
     if (!builder.storeOnDisk) {
       gcloudCommand.add("--no-store-on-disk");
     }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.datastore.testing;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.google.api.core.InternalApi;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.ServiceOptions;
@@ -70,6 +72,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
   private static final String CONSISTENCY_FLAG = "--consistency=";
   private static final String PROJECT_FLAG = "--project=";
   private static final double DEFAULT_CONSISTENCY = 0.9;
+  private static final String DEFAULT_PROJECT_ID = PROJECT_ID_PREFIX + UUID.randomUUID();
 
   private static final Logger LOGGER = Logger.getLogger(LocalDatastoreHelper.class.getName());
 
@@ -91,6 +94,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
     private int port;
     private Path dataDir;
     private boolean storeOnDisk = true;
+    private String projectId;
 
     private Builder() {}
 
@@ -107,6 +111,11 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
 
     public Builder setPort(int port) {
       this.port = port;
+      return this;
+    }
+
+    public Builder setProjectId(String projectId) {
+      this.projectId = projectId;
       return this;
     }
 
@@ -130,7 +139,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
     super(
         "datastore",
         builder.port > 0 ? builder.port : BaseEmulatorHelper.findAvailablePort(DEFAULT_PORT),
-        PROJECT_ID_PREFIX + UUID.randomUUID().toString());
+        firstNonNull(builder.projectId, DEFAULT_PROJECT_ID));
     this.consistency = builder.consistency > 0 ? builder.consistency : DEFAULT_CONSISTENCY;
     this.gcdPath = builder.dataDir;
     this.storeOnDisk = builder.storeOnDisk;

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/ITLocalDatastoreHelperTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/ITLocalDatastoreHelperTest.java
@@ -89,6 +89,16 @@ public class ITLocalDatastoreHelperTest {
   }
 
   @Test
+  public void testCreateWithCustomProjectId() {
+    String customProjectId = "custom-project-id";
+    LocalDatastoreHelper helper =
+        LocalDatastoreHelper.newBuilder()
+            .setProjectId(customProjectId)
+            .build();
+    assertEquals(customProjectId, helper.getProjectId());
+  }
+
+  @Test
   public void testCreateWithToBuilder() throws IOException {
     LocalDatastoreHelper helper =
         LocalDatastoreHelper.newBuilder()

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/ITLocalDatastoreHelperTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/ITLocalDatastoreHelperTest.java
@@ -92,9 +92,7 @@ public class ITLocalDatastoreHelperTest {
   public void testCreateWithCustomProjectId() {
     String customProjectId = "custom-project-id";
     LocalDatastoreHelper helper =
-        LocalDatastoreHelper.newBuilder()
-            .setProjectId(customProjectId)
-            .build();
+        LocalDatastoreHelper.newBuilder().setProjectId(customProjectId).build();
     assertEquals(customProjectId, helper.getProjectId());
   }
 


### PR DESCRIPTION
fix #355 

**Context:**
LocalDatastoreHelper starts a subprocess `gcloud beta emulators datastore start` to start the emulator, It is always starting the subprocess under the assumption that user have already set the project id property using `gcloud config set project some-project-id`.  If the `project-id` property is set, it'll result in successful execution of sub-process. Otherwise it'll throw the following error.

```
➜  java-datastore git:(main) gcloud beta emulators datastore start
WARNING: Reusing existing data in [/Users/jainsahab/.config/gcloud/emulators/datastore].
Executing: /Users/jainsahab/Work/bin/google-cloud-sdk/platform/cloud-datastore-emulator/cloud_datastore_emulator start --host=::1 --port=8045 --store_on_disk=True --allow_remote_shutdown --consistency=0.9 /Users/jainsahab/.config/gcloud/emulators/datastore
ERROR: (gcloud.beta.emulators.datastore.start) The required property [project] is not currently set.
It can be set on a per-command basis by re-running your command with the [--project] flag.

You may set it for your current workspace by running:

  $ gcloud config set project VALUE

or it can be set temporarily by the environment variable [CLOUDSDK_CORE_PROJECT]
```
_Note: To unset the project-id property, run `gcloud config unset project`_

[BlockingProcessStreamReader.java](https://github.com/googleapis/java-core/blob/main/google-cloud-core/src/main/java/com/google/cloud/testing/BlockingProcessStreamReader.java#L47-L61) file from [google-cloud-core library](https://github.com/googleapis/java-core) which is a java Thread **ignores this helpful text and the subprocess's exit code** to silently completes its own execution. Hence, no error was given to the user.


**Solution:**
As part of this PR, [google-cloud-core library](https://github.com/googleapis/java-core) (_[covered in this PR](https://github.com/googleapis/java-core/pull/1039)_) is out of scope, but we are explicitly passing [--project argument](https://cloud.google.com/sdk/gcloud/reference#--project) now while starting the emulator so that it no longer expect the `project-id` property to set.
In addition to that, we are also giving the user the capability to set a custom project Id.