### PR TITLE
chore: Remove @googleapis/api-firestore from being owner of this repo.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,11 +4,11 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/cloud-native-db-dpes @googleapis/api-firestore is the default owner for changes in this repo
-*                       @googleapis/yoshi-java @googleapis/cloud-native-db-dpes @googleapis/api-firestore
+# The @googleapis/cloud-native-db-dpes is the default owner for changes in this repo
+*                       @googleapis/yoshi-java @googleapis/cloud-native-db-dpes
 
 # for handwritten libraries, keep codeowner_team in .repo-metadata.json as owner
-**/*.java               @googleapis/cloud-native-db-dpes @googleapis/api-firestore
+**/*.java               @googleapis/cloud-native-db-dpes
 
 
 # The java-samples-reviewers team is the default owner for samples changes

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,7 +9,7 @@
   "repo": "googleapis/java-datastore",
   "repo_short": "java-datastore",
   "distribution_name": "com.google.cloud:google-cloud-datastore",
-  "codeowner_team": "@googleapis/cloud-native-db-dpes @googleapis/api-firestore",
+  "codeowner_team": "@googleapis/cloud-native-db-dpes",
   "api_id": "datastore.googleapis.com",
   "library_type": "GAPIC_COMBO",
   "api_description": "is a fully managed, schemaless database for\nstoring non-relational data. Cloud Datastore automatically scales with\nyour users and supports ACID transactions, high availability of reads and\nwrites, strong consistency for reads and ancestor queries, and eventual\nconsistency for all other queries.",

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.6.0')
+implementation platform('com.google.cloud:libraries-bom:26.7.0')
 
 implementation 'com.google.cloud:google-cloud-datastore'
 ```


### PR DESCRIPTION
Since this is Datastore and not Firestore, it makes sense to remove @googleapis/api-firestore from role of reviewing code.
