### PR TITLE
fix: Using --quiet flag to disable all interactive prompts when running datastore emulator

### DIFF
--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/GcloudEmulatorCommand.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/GcloudEmulatorCommand.java
@@ -15,8 +15,8 @@
  */
 package com.google.cloud.datastore.testing;
 
-import static com.google.cloud.datastore.testing.LocalDatastoreHelper.PROJECT_FLAG;
 import static com.google.cloud.datastore.testing.LocalDatastoreHelper.CONSISTENCY_FLAG;
+import static com.google.cloud.datastore.testing.LocalDatastoreHelper.PROJECT_FLAG;
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 import com.google.api.core.InternalApi;
@@ -25,9 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-/**
- * Utility to configure gcloud datastore emulator command.
- */
+/** Utility to configure gcloud datastore emulator command. */
 @InternalApi
 public class GcloudEmulatorCommand {
 
@@ -38,7 +36,6 @@ public class GcloudEmulatorCommand {
 
   private static final String PROJECT_ID_PREFIX = "test-project-";
   private static final String DEFAULT_PROJECT_ID = PROJECT_ID_PREFIX + UUID.randomUUID();
-
 
   public static List<String> get(LocalDatastoreHelper.Builder builder, int port) {
     String projectId = firstNonNull(builder.getProjectId(), DEFAULT_PROJECT_ID);

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/GcloudEmulatorCommand.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/GcloudEmulatorCommand.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.datastore.testing;
+
+import static com.google.cloud.datastore.testing.LocalDatastoreHelper.PROJECT_FLAG;
+import static com.google.cloud.datastore.testing.LocalDatastoreHelper.CONSISTENCY_FLAG;
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import com.google.api.core.InternalApi;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Utility to configure gcloud datastore emulator command.
+ */
+@InternalApi
+public class GcloudEmulatorCommand {
+
+  // Gcloud emulator settings
+  private static final String GCLOUD_CMD_TEXT = "gcloud --quiet beta emulators datastore start";
+  private static final String GCLOUD_CMD_PORT_FLAG = "--host-port=";
+  public static final String VERSION_PREFIX = "cloud-datastore-emulator ";
+
+  private static final String PROJECT_ID_PREFIX = "test-project-";
+  private static final String DEFAULT_PROJECT_ID = PROJECT_ID_PREFIX + UUID.randomUUID();
+
+
+  public static List<String> get(LocalDatastoreHelper.Builder builder, int port) {
+    String projectId = firstNonNull(builder.getProjectId(), DEFAULT_PROJECT_ID);
+    List<String> gcloudCommand = new ArrayList<>(Arrays.asList(GCLOUD_CMD_TEXT.split(" ")));
+    gcloudCommand.add(GCLOUD_CMD_PORT_FLAG + "localhost:" + port);
+    gcloudCommand.add(CONSISTENCY_FLAG + builder.getConsistency());
+    gcloudCommand.add(PROJECT_FLAG + projectId);
+    if (!builder.isStoreOnDisk()) {
+      gcloudCommand.add("--no-store-on-disk");
+    }
+    if (builder.getDataDir() != null) {
+      gcloudCommand.add("--data-dir=" + builder.getDataDir());
+    }
+    return gcloudCommand;
+  }
+}

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -131,9 +131,11 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
     double getConsistency() {
       return consistency;
     }
+
     boolean isStoreOnDisk() {
       return storeOnDisk;
     }
+
     String getProjectId() {
       return projectId;
     }
@@ -161,7 +163,8 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
       binName = BIN_NAME.replace("/", "\\");
     }
     GcloudEmulatorRunner gcloudRunner =
-        new GcloudEmulatorRunner(GcloudEmulatorCommand.get(builder, getPort()), VERSION_PREFIX, MIN_VERSION);
+        new GcloudEmulatorRunner(
+            GcloudEmulatorCommand.get(builder, getPort()), VERSION_PREFIX, MIN_VERSION);
     List<String> binCommand = new ArrayList<>(Arrays.asList(binName, "start"));
     binCommand.add("--testing");
     binCommand.add(BIN_CMD_PORT_FLAG + getPort());

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/GcloudEmulatorCommandTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/GcloudEmulatorCommandTest.java
@@ -18,12 +18,14 @@ package com.google.cloud.datastore.testing;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
-import java.util.function.Predicate;
 import org.junit.Before;
 import org.junit.Test;
 
-public class GcloudEmulatorCommandTest  {
+public class GcloudEmulatorCommandTest {
+
+  private static Path TEMP_DIR = new File(System.getProperty("java.io.tmpdir")).toPath();
 
   private List<String> gcloudEmulatorCommand;
 
@@ -34,7 +36,7 @@ public class GcloudEmulatorCommandTest  {
             .setConsistency(0.75)
             .setPort(8081)
             .setProjectId("my-project-id")
-            .setDataDir(new File("/data/datastore").toPath());
+            .setDataDir(TEMP_DIR);
 
     gcloudEmulatorCommand = GcloudEmulatorCommand.get(builder, 8080);
   }
@@ -64,13 +66,15 @@ public class GcloudEmulatorCommandTest  {
   public void defaultProjectIdFlag() {
     LocalDatastoreHelper.Builder builder = LocalDatastoreHelper.newBuilder().setProjectId(null);
 
-    assertThat(GcloudEmulatorCommand.get(builder, 0).stream().anyMatch(
-        s -> s.startsWith("--project=test-project"))).isTrue();
+    assertThat(
+            GcloudEmulatorCommand.get(builder, 0).stream()
+                .anyMatch(s -> s.startsWith("--project=test-project")))
+        .isTrue();
   }
 
   @Test
   public void dataDirFlag() {
-    assertThat(gcloudEmulatorCommand.contains("--data-dir=/data/datastore")).isTrue();
+    assertThat(gcloudEmulatorCommand.contains("--data-dir=" + TEMP_DIR)).isTrue();
   }
 
   @Test

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/GcloudEmulatorCommandTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/GcloudEmulatorCommandTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.datastore.testing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.File;
+import java.util.List;
+import java.util.function.Predicate;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GcloudEmulatorCommandTest  {
+
+  private List<String> gcloudEmulatorCommand;
+
+  @Before
+  public void setUp() throws Exception {
+    LocalDatastoreHelper.Builder builder =
+        LocalDatastoreHelper.newBuilder()
+            .setConsistency(0.75)
+            .setPort(8081)
+            .setProjectId("my-project-id")
+            .setDataDir(new File("/data/datastore").toPath());
+
+    gcloudEmulatorCommand = GcloudEmulatorCommand.get(builder, 8080);
+  }
+
+  @Test
+  public void binNameWithDatastoreEmulatorStartOption() {
+    String commandText = String.join(" ", gcloudEmulatorCommand);
+    assertThat(commandText.startsWith("gcloud --quiet beta emulators datastore start")).isTrue();
+  }
+
+  @Test
+  public void portFlag() {
+    assertThat(gcloudEmulatorCommand.contains("--host-port=localhost:8080")).isTrue();
+  }
+
+  @Test
+  public void consistencyFlag() {
+    assertThat(gcloudEmulatorCommand.contains("--consistency=0.75")).isTrue();
+  }
+
+  @Test
+  public void projectIdFlag() {
+    assertThat(gcloudEmulatorCommand.contains("--project=my-project-id")).isTrue();
+  }
+
+  @Test
+  public void defaultProjectIdFlag() {
+    LocalDatastoreHelper.Builder builder = LocalDatastoreHelper.newBuilder().setProjectId(null);
+
+    assertThat(GcloudEmulatorCommand.get(builder, 0).stream().anyMatch(
+        s -> s.startsWith("--project=test-project"))).isTrue();
+  }
+
+  @Test
+  public void dataDirFlag() {
+    assertThat(gcloudEmulatorCommand.contains("--data-dir=/data/datastore")).isTrue();
+  }
+
+  @Test
+  public void NoStoreOnDiskFlagShouldBeAbsent() {
+    assertThat(gcloudEmulatorCommand.contains("--no-store-on-disk")).isFalse();
+  }
+
+  @Test
+  public void NoStoreOnDiskFlagShouldBePresent() {
+    LocalDatastoreHelper.Builder builder = LocalDatastoreHelper.newBuilder().setStoreOnDisk(false);
+
+    assertThat(GcloudEmulatorCommand.get(builder, 0).contains("--no-store-on-disk")).isTrue();
+  }
+}


### PR DESCRIPTION
Fixes googleapis/google-cloud-java#12002  ☕️

`LocalDatastoreHelper` works on top of `gcloud` utility and relies on the user input in this specific scenario, As LocalDatastoreHelper programmatically controls the gcloud command, we are using [--quiet](https://cloud.google.com/sdk/gcloud/reference#--quiet) flag to disable all the prompts for user inputs and use default values instead. 

Steps to reproduce (from googleapis/google-cloud-java#12002 itself)

- Remove beta component `gcloud components remove beta`
- Run the following code
```
public class DatastoreGithubIssue302 {
  public static void main(String[] args) throws Exception {
    LocalDatastoreHelper emulator = LocalDatastoreHelper.create();
    emulator.start();

    System.out.println("Started!"); // will never be printed
  }
}
```



Also, refactoring the code a bit by configuring the gcloud datastore emulator command in a separate utility.