### PR TITLE
docs: fix broken README links

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -119,11 +119,9 @@ You can test against a temporary local Datastore by following these steps:
 
 To determine which host/port the emulator is running on:
 
-```
 $ gcloud beta emulators datastore env-init
 # Sample output:
 #   export DATASTORE_EMULATOR_HOST=localhost:8759
-```
   
   3. Point your client to the emulator
   

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -119,11 +119,11 @@ You can test against a temporary local Datastore by following these steps:
 
 To determine which host/port the emulator is running on:
 
-  ```
-  $ gcloud beta emulators datastore env-init
-  # Sample output:
-  #   export DATASTORE_EMULATOR_HOST=localhost:8759
-  ```
+```
+$ gcloud beta emulators datastore env-init
+# Sample output:
+#   export DATASTORE_EMULATOR_HOST=localhost:8759
+```
   
   3. Point your client to the emulator
   

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -95,12 +95,12 @@ custom_content: |
   ```
 
   The complete source code can be found at
-  [UpdateEntity.java](../../google-cloud-examples/src/main/java/com/google/cloud/examples/datastore/snippets/UpdateEntity.java).
+  [UpdateEntity.java](https://github.com/googleapis/google-cloud-java/blob/2c1850d4f82f3fbd7b4a50582384c008085aa1a8/google-cloud-examples/src/main/java/com/google/cloud/examples/datastore/snippets/UpdateEntity.java).
 
   #### Complete source code
 
   In
-  [AddEntitiesAndRunQuery.java](../../google-cloud-examples/src/main/java/com/google/cloud/examples/datastore/snippets/AddEntitiesAndRunQuery.java)
+  [AddEntitiesAndRunQuery.java](https://github.com/googleapis/google-cloud-java/blob/2c1850d4f82f3fbd7b4a50582384c008085aa1a8/google-cloud-examples/src/main/java/com/google/cloud/examples/datastore/snippets/AddEntitiesAndRunQuery.java)
   we put together all the code to store data and run queries into one program. The program assumes that you are
   running on Compute Engine or from your own desktop. To run the example on App Engine, simply move
   the code from the main method to your application's servlet class and change the print statements to
@@ -110,8 +110,31 @@ custom_content: |
   -------
 
   This library has tools to help write tests for code that uses the Datastore.
+  
+  #### On your machine
 
-  See [TESTING.md](https://github.com/googleapis/google-cloud-java/blob/main/TESTING.md#testing-code-that-uses-datastore) to read more about testing.
+You can test against a temporary local Datastore by following these steps:
+
+  1. [Install Cloud SDK and start the emulator](https://cloud.google.com/datastore/docs/tools/datastore-emulator)
+
+To determine which host/port the emulator is running on:
+  ```
+  $ gcloud beta emulators datastore env-init
+  # Sample output:
+  #   export DATASTORE_EMULATOR_HOST=localhost:8759
+  ```
+  3. Point your client to the emulator
+  
+  ```java
+  DatastoreOptions options = DatastoreOptions.newBuilder()
+  .setProjectId(DatastoreOptions.getDefaultProjectId())
+  .setHost(System.getenv("DATASTORE_EMULATOR_HOST"))
+  .setCredentials(NoCredentials.getInstance())
+  .setRetrySettings(ServiceOptions.getNoRetrySettings())
+  .build();
+  Datastore datastore = options.getService();
+  ```
+  4. Run your tests
 
   Example Applications
   --------------------

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -81,7 +81,7 @@ custom_content: |
   #### Updating data
   Another thing you'll probably want to do is update your data. The following snippet shows how to update a Datastore entity if it exists.
 
-  ``` java
+  ```java
   KeyFactory keyFactory = datastore.newKeyFactory().setKind("keyKind");
   Key key = keyFactory.newKey("keyName");
   Entity entity = datastore.get(key);
@@ -118,11 +118,13 @@ You can test against a temporary local Datastore by following these steps:
   1. [Install Cloud SDK and start the emulator](https://cloud.google.com/datastore/docs/tools/datastore-emulator)
 
 To determine which host/port the emulator is running on:
+
   ```
   $ gcloud beta emulators datastore env-init
   # Sample output:
   #   export DATASTORE_EMULATOR_HOST=localhost:8759
   ```
+  
   3. Point your client to the emulator
   
   ```java

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -113,15 +113,18 @@ custom_content: |
   
   #### On your machine
 
-You can test against a temporary local Datastore by following these steps:
+  You can test against a temporary local Datastore by following these steps:
 
   1. [Install Cloud SDK and start the emulator](https://cloud.google.com/datastore/docs/tools/datastore-emulator)
 
-To determine which host/port the emulator is running on:
-
-$ gcloud beta emulators datastore env-init
-# Sample output:
-#   export DATASTORE_EMULATOR_HOST=localhost:8759
+  To determine which host/port the emulator is running on:
+  
+  ```
+  $ gcloud beta emulators datastore env-init
+  
+  # Sample output:
+  #   export DATASTORE_EMULATOR_HOST=localhost:8759
+  ```
   
   3. Point your client to the emulator
   

--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.9.0')
+implementation platform('com.google.cloud:libraries-bom:26.10.0')
 
 implementation 'com.google.cloud:google-cloud-datastore'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-datastore:2.13.6'
+implementation 'com.google.cloud:google-cloud-datastore:2.14.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.13.6"
+libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.14.0"
 ```
 
 ## Authentication
@@ -183,7 +183,7 @@ Cloud Datastore relies on indexing to run queries. Indexing is turned on by defa
 #### Updating data
 Another thing you'll probably want to do is update your data. The following snippet shows how to update a Datastore entity if it exists.
 
-``` java
+```java
 KeyFactory keyFactory = datastore.newKeyFactory().setKind("keyKind");
 Key key = keyFactory.newKey("keyName");
 Entity entity = datastore.get(key);
@@ -197,12 +197,12 @@ if (entity != null) {
 ```
 
 The complete source code can be found at
-[UpdateEntity.java](../../google-cloud-examples/src/main/java/com/google/cloud/examples/datastore/snippets/UpdateEntity.java).
+[UpdateEntity.java](https://github.com/googleapis/google-cloud-java/blob/2c1850d4f82f3fbd7b4a50582384c008085aa1a8/google-cloud-examples/src/main/java/com/google/cloud/examples/datastore/snippets/UpdateEntity.java).
 
 #### Complete source code
 
 In
-[AddEntitiesAndRunQuery.java](../../google-cloud-examples/src/main/java/com/google/cloud/examples/datastore/snippets/AddEntitiesAndRunQuery.java)
+[AddEntitiesAndRunQuery.java](https://github.com/googleapis/google-cloud-java/blob/2c1850d4f82f3fbd7b4a50582384c008085aa1a8/google-cloud-examples/src/main/java/com/google/cloud/examples/datastore/snippets/AddEntitiesAndRunQuery.java)
 we put together all the code to store data and run queries into one program. The program assumes that you are
 running on Compute Engine or from your own desktop. To run the example on App Engine, simply move
 the code from the main method to your application's servlet class and change the print statements to
@@ -213,7 +213,33 @@ Testing
 
 This library has tools to help write tests for code that uses the Datastore.
 
-See [TESTING.md](https://github.com/googleapis/google-cloud-java/blob/main/TESTING.md#testing-code-that-uses-datastore) to read more about testing.
+#### On your machine
+
+You can test against a temporary local Datastore by following these steps:
+
+1. [Install Cloud SDK and start the emulator](https://cloud.google.com/datastore/docs/tools/datastore-emulator)
+
+To determine which host/port the emulator is running on:
+
+```
+$ gcloud beta emulators datastore env-init
+
+# Sample output:
+#   export DATASTORE_EMULATOR_HOST=localhost:8759
+```
+
+3. Point your client to the emulator
+
+```java
+DatastoreOptions options = DatastoreOptions.newBuilder()
+.setProjectId(DatastoreOptions.getDefaultProjectId())
+.setHost(System.getenv("DATASTORE_EMULATOR_HOST"))
+.setCredentials(NoCredentials.getInstance())
+.setRetrySettings(ServiceOptions.getNoRetrySettings())
+.build();
+Datastore datastore = options.getService();
+```
+4. Run your tests
 
 Example Applications
 --------------------


### PR DESCRIPTION
Fixes #1000

update links, inline TESTING.md content (used to be located in google-cloud-java, the file has since been removed)