### PR TITLE
docs: Marking Transaction, Batch and DatastoreBatchWriter class with 'NotThreadSafe' annotation

### DIFF
--- a/google-cloud-datastore/pom.xml
+++ b/google-cloud-datastore/pom.xml
@@ -106,6 +106,10 @@
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Batch.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Batch.java
@@ -34,12 +34,12 @@ import javax.annotation.concurrent.NotThreadSafe;
  * batch.submit();
  * }</pre>
  *
- * <p><b> WARNING: THIS CLASS MAINTAINS AN INTERNAL STATE IN TERMS OF {@link
- * java.util.LinkedHashMap} AND {@link java.util.LinkedHashSet} WHICH GETS UPDATED ON EVERY METHOD
- * CALL PERFORMING CRUD OPERATIONS TO RECORD THE MUTATIONS, SINCE {@link java.util.LinkedHashMap} IS
- * NOT THREAD SAFE AS PER ITS <a
- * href="https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html">DOCUMENTATION</a>.
- * THIS CLASS TOO SHOULD NOT BE TREATED AS A THREAD SAFE CLASS. </b>
+ * <p><b> WARNING: This class maintains an internal state in terms of {@link
+ * java.util.LinkedHashMap} and {@link java.util.LinkedHashSet} which gets updated on every method
+ * call performing CRUD operations to record the mutations. Since {@link java.util.LinkedHashMap} is
+ * not thread safe as per its <a
+ * href="https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html">documentation</a>,
+ * This class too should not be treated as a thread safe class. </b>
  */
 @NotThreadSafe
 public interface Batch extends DatastoreBatchWriter {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Batch.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Batch.java
@@ -17,6 +17,7 @@
 package com.google.cloud.datastore;
 
 import java.util.List;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * An interface to represent a batch of write operations. Any write operation that is applied on a
@@ -32,7 +33,15 @@ import java.util.List;
  * batch.add(entity2, entity3);
  * batch.submit();
  * }</pre>
+ *
+ * <p><b> WARNING: THIS CLASS MAINTAINS AN INTERNAL STATE IN TERMS OF {@link
+ * java.util.LinkedHashMap} AND {@link java.util.LinkedHashSet} WHICH GETS UPDATED ON EVERY METHOD
+ * CALL PERFORMING CRUD OPERATIONS TO RECORD THE MUTATIONS, SINCE {@link java.util.LinkedHashMap} IS
+ * NOT THREAD SAFE AS PER ITS <a
+ * href="https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html">DOCUMENTATION</a>.
+ * THIS CLASS TOO SHOULD NOT BE TREATED AS A THREAD SAFE CLASS. </b>
  */
+@NotThreadSafe
 public interface Batch extends DatastoreBatchWriter {
 
   interface Response {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreBatchWriter.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreBatchWriter.java
@@ -23,12 +23,12 @@ import javax.annotation.concurrent.NotThreadSafe;
  * An interface to represent a batch of write operations. All write operation for a batch writer
  * will be applied to the Datastore in one RPC call.
  *
- * <p><b> WARNING: THIS CLASS MAINTAINS AN INTERNAL STATE IN TERMS OF {@link
- * java.util.LinkedHashMap} AND {@link java.util.LinkedHashSet} WHICH GETS UPDATED ON EVERY METHOD
- * CALL PERFORMING CRUD OPERATIONS TO RECORD THE MUTATIONS, SINCE {@link java.util.LinkedHashMap} IS
- * NOT THREAD SAFE AS PER ITS <a
- * href="https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html">DOCUMENTATION</a>.
- * THIS CLASS TOO SHOULD NOT BE TREATED AS A THREAD SAFE CLASS. </b>
+ * <p><b> WARNING: This class maintains an internal state in terms of {@link
+ * java.util.LinkedHashMap} and {@link java.util.LinkedHashSet} which gets updated on every method
+ * call performing CRUD operations to record the mutations. Since {@link java.util.LinkedHashMap} is
+ * not thread safe as per its <a
+ * href="https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html">documentation</a>,
+ * This class too should not be treated as a thread safe class. </b>
  */
 @NotThreadSafe
 public interface DatastoreBatchWriter extends DatastoreWriter {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreBatchWriter.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreBatchWriter.java
@@ -17,11 +17,20 @@
 package com.google.cloud.datastore;
 
 import java.util.List;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * An interface to represent a batch of write operations. All write operation for a batch writer
  * will be applied to the Datastore in one RPC call.
+ *
+ * <p><b> WARNING: THIS CLASS MAINTAINS AN INTERNAL STATE IN TERMS OF {@link
+ * java.util.LinkedHashMap} AND {@link java.util.LinkedHashSet} WHICH GETS UPDATED ON EVERY METHOD
+ * CALL PERFORMING CRUD OPERATIONS TO RECORD THE MUTATIONS, SINCE {@link java.util.LinkedHashMap} IS
+ * NOT THREAD SAFE AS PER ITS <a
+ * href="https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html">DOCUMENTATION</a>.
+ * THIS CLASS TOO SHOULD NOT BE TREATED AS A THREAD SAFE CLASS. </b>
  */
+@NotThreadSafe
 public interface DatastoreBatchWriter extends DatastoreWriter {
 
   /**

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Transaction.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Transaction.java
@@ -53,12 +53,12 @@ import javax.annotation.concurrent.NotThreadSafe;
  *
  * @see <a href="https://cloud.google.com/datastore/docs/concepts/transactions">Google Cloud
  *     Datastore transactions</a>
- *     <p><b> WARNING: THIS CLASS MAINTAINS AN INTERNAL STATE IN TERMS OF {@link
- *     java.util.LinkedHashMap} AND {@link java.util.LinkedHashSet} WHICH GETS UPDATED ON EVERY
- *     METHOD CALL PERFORMING CRUD OPERATIONS TO RECORD THE MUTATIONS, SINCE {@link
- *     java.util.LinkedHashMap} IS NOT THREAD SAFE AS PER ITS <a
- *     href="https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html">DOCUMENTATION</a>.
- *     THIS CLASS TOO SHOULD NOT BE TREATED AS A THREAD SAFE CLASS. </b>
+ * <p><b> WARNING: This class maintains an internal state in terms of {@link
+ * java.util.LinkedHashMap} and {@link java.util.LinkedHashSet} which gets updated on every method
+ * call performing CRUD operations to record the mutations. Since {@link java.util.LinkedHashMap} is
+ * not thread safe as per its <a
+ * href="https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html">documentation</a>,
+ * This class too should not be treated as a thread safe class. </b>
  */
 @NotThreadSafe
 public interface Transaction extends DatastoreBatchWriter, DatastoreReaderWriter {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Transaction.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Transaction.java
@@ -19,13 +19,14 @@ package com.google.cloud.datastore;
 import com.google.protobuf.ByteString;
 import java.util.Iterator;
 import java.util.List;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * A Google cloud datastore transaction. Similar to {@link Batch} any write operation that is
  * applied on a transaction will only be sent to the Datastore upon {@link #commit}. A call to
  * {@link #rollback} will invalidate the transaction and discard the changes. Any read operation
  * that is done by a transaction will be part of it and therefore a {@code commit} is guaranteed to
- * fail if an entity was modified outside of the transaction after it was read. Write operation on
+ * fail if an entity was modified outside the transaction after it was read. Write operation on
  * this transaction will not be reflected by read operation (as the changes are only sent to the
  * Datastore upon {@code commit}. A usage example:
  *
@@ -52,7 +53,14 @@ import java.util.List;
  *
  * @see <a href="https://cloud.google.com/datastore/docs/concepts/transactions">Google Cloud
  *     Datastore transactions</a>
+ *     <p><b> WARNING: THIS CLASS MAINTAINS AN INTERNAL STATE IN TERMS OF {@link
+ *     java.util.LinkedHashMap} AND {@link java.util.LinkedHashSet} WHICH GETS UPDATED ON EVERY
+ *     METHOD CALL PERFORMING CRUD OPERATIONS TO RECORD THE MUTATIONS, SINCE {@link
+ *     java.util.LinkedHashMap} IS NOT THREAD SAFE AS PER ITS <a
+ *     href="https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html">DOCUMENTATION</a>.
+ *     THIS CLASS TOO SHOULD NOT BE TREATED AS A THREAD SAFE CLASS. </b>
  */
+@NotThreadSafe
 public interface Transaction extends DatastoreBatchWriter, DatastoreReaderWriter {
 
   interface Response {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Transaction.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Transaction.java
@@ -53,12 +53,12 @@ import javax.annotation.concurrent.NotThreadSafe;
  *
  * @see <a href="https://cloud.google.com/datastore/docs/concepts/transactions">Google Cloud
  *     Datastore transactions</a>
- * <p><b> WARNING: This class maintains an internal state in terms of {@link
- * java.util.LinkedHashMap} and {@link java.util.LinkedHashSet} which gets updated on every method
- * call performing CRUD operations to record the mutations. Since {@link java.util.LinkedHashMap} is
- * not thread safe as per its <a
- * href="https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html">documentation</a>,
- * This class too should not be treated as a thread safe class. </b>
+ *     <p><b> WARNING: This class maintains an internal state in terms of {@link
+ *     java.util.LinkedHashMap} and {@link java.util.LinkedHashSet} which gets updated on every
+ *     method call performing CRUD operations to record the mutations. Since {@link
+ *     java.util.LinkedHashMap} is not thread safe as per its <a
+ *     href="https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html">documentation</a>,
+ *     This class too should not be treated as a thread safe class. </b>
  */
 @NotThreadSafe
 public interface Transaction extends DatastoreBatchWriter, DatastoreReaderWriter {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Transaction.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Transaction.java
@@ -26,8 +26,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  * applied on a transaction will only be sent to the Datastore upon {@link #commit}. A call to
  * {@link #rollback} will invalidate the transaction and discard the changes. Any read operation
  * that is done by a transaction will be part of it and therefore a {@code commit} is guaranteed to
- * fail if an entity was modified outside the transaction after it was read. Write operation on
- * this transaction will not be reflected by read operation (as the changes are only sent to the
+ * fail if an entity was modified outside the transaction after it was read. Write operation on this
+ * transaction will not be reflected by read operation (as the changes are only sent to the
  * Datastore upon {@code commit}. A usage example:
  *
  * <pre>{@code


### PR DESCRIPTION
Documenting the thread unsafe behaviour of Transaction, Batch and DatastoreBatchWriter classes.

Fixes #295

