### PR TITLE
test(fix): set namespace for entity

### DIFF
--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITDatastoreTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITDatastoreTest.java
@@ -194,6 +194,7 @@ public class ITDatastoreTest {
         FullEntity.newBuilder(PARTIAL_ENTITY1)
             .setKey(
                 IncompleteKey.newBuilder(PROJECT_ID, KIND3)
+                    .setNamespace(NAMESPACE)
                     .setDatabaseId(options.getDatabaseId())
                     .build())
             .build();


### PR DESCRIPTION
Because we were calling `setKey`, the namespace was getting overwritten to `[default]` and not getting cleaned up after tests were run as a result.