### PR TITLE
chore: setup 2.15.x lts branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -22,3 +22,7 @@ branches:
     handleGHRelease: true
     releaseType: java-backport
     branch: 2.12.x
+  - bumpMinorPreMajor: true
+    handleGHRelease: true
+    releaseType: java-backport
+    branch: 2.15.x

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -111,6 +111,22 @@ branchProtectionRules:
       - OwlBot Post Processor
       - 'Kokoro - Test: Java GraalVM Native Image'
       - 'Kokoro - Test: Java 17 GraalVM Native Image'
+  - pattern: 2.15.x
+    isAdminEnforced: true
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: false
+    requiredStatusCheckContexts:
+      - dependencies (17)
+      - lint
+      - clirr
+      - units (8)
+      - units (11)
+      - 'Kokoro - Test: Integration'
+      - cla/google
+      - OwlBot Post Processor
+      - 'Kokoro - Test: Java GraalVM Native Image'
+      - 'Kokoro - Test: Java 17 GraalVM Native Image'
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
enable releases

```
release-brancher create-pull-request \
  --branch-name="2.15.x" \
  --target-tag="v2.15.0" \
  --repo="googleapis/java-datastore" \
  --pull-request-title="chore: setup 2.15.x lts branch" \
  --release-type=java-backport
```