### PR TITLE
chore: rework checksum benchmark

### DIFF
--- a/datastore-v1-proto-client/src/test/java/com/google/datastore/v1/client/ChecksumEnforcingInputStreamTest.java
+++ b/datastore-v1-proto-client/src/test/java/com/google/datastore/v1/client/ChecksumEnforcingInputStreamTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -47,7 +46,7 @@ public class ChecksumEnforcingInputStreamTest {
     } catch (IOException e) {
       fail("checksum verification failed! " + e.getMessage());
     }
-    
+
     try (ByteArrayInputStream testInstance = new ByteArrayInputStream(payload)) {
       byte[] buf = new byte[chunkSize];
       start = System.nanoTime();
@@ -59,7 +58,7 @@ public class ChecksumEnforcingInputStreamTest {
       fail("checksum verification failed! " + e.getMessage());
     }
 
-    return new long[]{noChecksumTime, checksumTime, computeTime};
+    return new long[] {noChecksumTime, checksumTime, computeTime};
   }
 
   @Test
@@ -81,7 +80,7 @@ public class ChecksumEnforcingInputStreamTest {
     for (int i = 0; i < iterations; i++) {
       // test with various payload sizes (1, 2, 2**2, 2**3 etc upto 2**28 = 256MB)
       for (int j = minPower - 1; j < maxPower; j++) {
-        long[] result = test((int) Math.pow(2,j));
+        long[] result = test((int) Math.pow(2, j));
         readNoChecksum[j][i] = result[0];
         readAndChecksum[j][i] = result[1];
         compute[j][i] = result[2];
@@ -94,7 +93,7 @@ public class ChecksumEnforcingInputStreamTest {
       Arrays.sort(compute[j]);
       System.out.println(
           "Payload "
-              + (int) Math.pow(2,j) / 1024
+              + (int) Math.pow(2, j) / 1024
               + " KB stream read: "
               + readNoChecksum[j][median] / 1000.0
               + " μs; stream read and calculate checksum: "

--- a/datastore-v1-proto-client/src/test/java/com/google/datastore/v1/client/ChecksumEnforcingInputStreamTest.java
+++ b/datastore-v1-proto-client/src/test/java/com/google/datastore/v1/client/ChecksumEnforcingInputStreamTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Arrays;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,39 +30,88 @@ import org.junit.runners.JUnit4;
 /** Test for {@link ChecksumEnforcingInputStream}. */
 @RunWith(JUnit4.class)
 public class ChecksumEnforcingInputStreamTest {
-  public void test(int payloadSize) throws Exception {
-    // read 1000 bytes at a time
-    // Since checksum should be correct, do not expect IOException
-    try (ChecksumEnforcingInputStream testInstance = setUpData(payloadSize)) {
-      byte[] buf = new byte[1000];
-      while (testInstance.read(buf, 0, 1000) != -1) {
+  public long[] test(int payloadSize) throws Exception {
+    int chunkSize = 10240;
+    byte[] payload = preparePayload(payloadSize);
+    long start = System.nanoTime();
+    String expectedChecksum = EndToEndChecksumHandler.computeChecksum(payload);
+    long computeTime = System.nanoTime() - start;
+    long checksumTime = 0, noChecksumTime = 0;
+    try (ChecksumEnforcingInputStream testInstance = createStream(expectedChecksum, payload)) {
+      byte[] buf = new byte[chunkSize];
+      start = System.nanoTime();
+      while (testInstance.read(buf, 0, chunkSize) != -1) {
         // do nothing with the bytes read
       }
+      checksumTime = System.nanoTime() - start;
     } catch (IOException e) {
       fail("checksum verification failed! " + e.getMessage());
     }
+    
+    try (ByteArrayInputStream testInstance = new ByteArrayInputStream(payload)) {
+      byte[] buf = new byte[chunkSize];
+      start = System.nanoTime();
+      while (testInstance.read(buf, 0, chunkSize) != -1) {
+        // do nothing with the bytes read
+      }
+      noChecksumTime = System.nanoTime() - start;
+    } catch (IOException e) {
+      fail("checksum verification failed! " + e.getMessage());
+    }
+
+    return new long[]{noChecksumTime, checksumTime, computeTime};
   }
 
   @Test
   public void read_withValidChecksum_differentPayloadSizes() throws Exception {
-    // test with various payload sizes (1, 2, 2**2, 2**3 etc upto 2**28 = 256MB)
-    for (int i = 0, payloadSize = 1; i < 29; i++) {
-      long start = System.currentTimeMillis();
-      test(payloadSize);
-      payloadSize *= 2;
-      long duration = System.currentTimeMillis() - start;
-      // log test duration times for bigger payloads
-      if (i > 20) {
-        System.out.println("Test duration for payloadsize = 2** " + i + " is: " + duration + "ms");
+    int iterations = 3;
+    int median = iterations / 2;
+    int minPower = 15;
+    int maxPower = 29;
+    long[][] readNoChecksum = new long[maxPower][];
+    long[][] readAndChecksum = new long[maxPower][];
+    long[][] compute = new long[maxPower][];
+
+    for (int j = minPower - 1; j < maxPower; j++) {
+      readNoChecksum[j] = new long[iterations];
+      readAndChecksum[j] = new long[iterations];
+      compute[j] = new long[iterations];
+    }
+
+    for (int i = 0; i < iterations; i++) {
+      // test with various payload sizes (1, 2, 2**2, 2**3 etc upto 2**28 = 256MB)
+      for (int j = minPower - 1; j < maxPower; j++) {
+        long[] result = test((int) Math.pow(2,j));
+        readNoChecksum[j][i] = result[0];
+        readAndChecksum[j][i] = result[1];
+        compute[j][i] = result[2];
       }
+    }
+
+    for (int j = minPower; j < maxPower; j++) {
+      Arrays.sort(readNoChecksum[j]);
+      Arrays.sort(readAndChecksum[j]);
+      Arrays.sort(compute[j]);
+      System.out.println(
+          "Payload "
+              + (int) Math.pow(2,j) / 1024
+              + " KB stream read: "
+              + readNoChecksum[j][median] / 1000.0
+              + " μs; stream read and calculate checksum: "
+              + readAndChecksum[j][median] / 1000.0
+              + " μs; stream checksum overhead: "
+              + (readAndChecksum[j][median] - readNoChecksum[j][median]) / 1000.0
+              + " μs; calculate checksum: "
+              + compute[j][median] / 1000.0
+              + " μs.");
     }
   }
 
   @Test
   public void read_withInvalidChecksum() {
-    // build a test instance with invalidchecksum
-    // read 1000 bytes at a time
-    // Since checksum should be correct, do not expect IOException
+    // Build a test instance with an invalid checksum.
+    // Read 1000 bytes at a time.
+    // Since checksum is invalid, do expect IOException.
     try (ChecksumEnforcingInputStream instance =
         new ChecksumEnforcingInputStream(
             new ByteArrayInputStream("hello there".getBytes(UTF_8)), "this checksum is invalid")) {
@@ -72,17 +123,19 @@ public class ChecksumEnforcingInputStreamTest {
       // this is expected
       return;
     }
-    fail("should have failed");
+    fail("should have raised IOException");
   }
 
   @Test
   public void markNotSupported() throws Exception {
-    try (ChecksumEnforcingInputStream testInstance = setUpData(1)) {
+    byte[] payload = preparePayload(1);
+    String expectedChecksum = EndToEndChecksumHandler.computeChecksum(payload);
+    try (ChecksumEnforcingInputStream testInstance = createStream(expectedChecksum, payload)) {
       assertFalse(testInstance.markSupported());
     }
   }
 
-  private ChecksumEnforcingInputStream setUpData(int payloadSize) throws Exception {
+  private byte[] preparePayload(int payloadSize) {
     // setup a String of size = input param: payloadSize
     String str = "This is a repeating string.";
     String payload;
@@ -96,8 +149,11 @@ public class ChecksumEnforcingInputStreamTest {
     } else {
       payload = str.substring(0, payloadSize);
     }
-    byte[] bytes = payload.getBytes(UTF_8);
-    String expectedChecksum = EndToEndChecksumHandler.computeChecksum(bytes);
-    return new ChecksumEnforcingInputStream(new ByteArrayInputStream(bytes), expectedChecksum);
+    return payload.getBytes(UTF_8);
+  }
+
+  private ChecksumEnforcingInputStream createStream(String checksum, byte[] bytes)
+      throws Exception {
+    return new ChecksumEnforcingInputStream(new ByteArrayInputStream(bytes), checksum);
   }
 }


### PR DESCRIPTION
Previously `read_withValidChecksum_differentPayloadSizes` output looked like this:

```
Test duration for payloadsize = 2** 21 is: 7ms
Test duration for payloadsize = 2** 22 is: 12ms
Test duration for payloadsize = 2** 23 is: 30ms
Test duration for payloadsize = 2** 24 is: 47ms
Test duration for payloadsize = 2** 25 is: 100ms
Test duration for payloadsize = 2** 26 is: 177ms
Test duration for payloadsize = 2** 27 is: 284ms
Test duration for payloadsize = 2** 28 is: 558ms
```

meaning that a stream of 256 MB payload gets read and its checksum calculated within 558 ms.

Which doesn't answer the question we are really interested in: "what overhead calculating the checksum adds?"

And secondly, it seems too much even for 256 MB. Turned out this is because the time to prepare the data was also included.

In this PR we fix that and measure:
1. Time to read the stream of prepared data.
2. Time to read the stream of prepared data and while reading calculate its checksum.
3. Time to calculate the checksum given prepared payload (no stream).

Then we calculate the overhead of calculating checksum while reading a stream by subtracting (2) from (1).

We also do several iterations and take the median to make sure we don't take into account the runs that were affected by GC or anything else.

Here is an example of the output I got using 21 iterations:

```
Payload 32 KB stream read: 1.17 μs; stream read and calculate checksum: 3.488 μs; stream checksum overhead: 2.318 μs; calculate checksum: 2.968 μs.
Payload 64 KB stream read: 1.704 μs; stream read and calculate checksum: 6.144 μs; stream checksum overhead: 4.44 μs; calculate checksum: 4.475 μs.
Payload 128 KB stream read: 4.022 μs; stream read and calculate checksum: 11.068 μs; stream checksum overhead: 7.046 μs; calculate checksum: 9.459 μs.
Payload 256 KB stream read: 8.1 μs; stream read and calculate checksum: 21.914 μs; stream checksum overhead: 13.814 μs; calculate checksum: 18.551 μs.
Payload 512 KB stream read: 16.514 μs; stream read and calculate checksum: 38.804 μs; stream checksum overhead: 22.29 μs; calculate checksum: 39.763 μs.
Payload 1024 KB stream read: 28.429 μs; stream read and calculate checksum: 89.425 μs; stream checksum overhead: 60.996 μs; calculate checksum: 73.045 μs.
Payload 2048 KB stream read: 86.047 μs; stream read and calculate checksum: 192.966 μs; stream checksum overhead: 106.919 μs; calculate checksum: 136.492 μs.
Payload 4096 KB stream read: 179.55 μs; stream read and calculate checksum: 392.152 μs; stream checksum overhead: 212.602 μs; calculate checksum: 293.744 μs.
Payload 8192 KB stream read: 362.823 μs; stream read and calculate checksum: 829.353 μs; stream checksum overhead: 466.53 μs; calculate checksum: 663.71 μs.
Payload 16384 KB stream read: 946.233 μs; stream read and calculate checksum: 1966.305 μs; stream checksum overhead: 1020.072 μs; calculate checksum: 1680.049 μs.
Payload 32768 KB stream read: 2557.4 μs; stream read and calculate checksum: 4354.165 μs; stream checksum overhead: 1796.765 μs; calculate checksum: 3659.762 μs.
Payload 65536 KB stream read: 5643.656 μs; stream read and calculate checksum: 8991.107 μs; stream checksum overhead: 3347.451 μs; calculate checksum: 7331.796 μs.
Payload 131072 KB stream read: 11287.92 μs; stream read and calculate checksum: 18033.975 μs; stream checksum overhead: 6746.055 μs; calculate checksum: 14713.583 μs.
Payload 262144 KB stream read: 22593.106 μs; stream read and calculate checksum: 36093.013 μs; stream checksum overhead: 13499.907 μs; calculate checksum: 29152.813 μs.
```

Now we can see, for example, that enabling checksums will add ~13.5ms for reading 256 MB of response or ~7ms for 128 MB; for 32KB it is ~2.3 microseconds.

For attaching checksums to requests the overhead will be the last column (calculate checksum).