### PR TITLE
feat: separate flags for request/response E2E checksum and enable request checksum by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.27.0')
+implementation platform('com.google.cloud:libraries-bom:26.28.0')
 
 implementation 'com.google.cloud:google-cloud-datastore'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-datastore:2.17.5'
+implementation 'com.google.cloud:google-cloud-datastore:2.17.6'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.17.5"
+libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.17.6"
 ```
 <!-- {x-version-update-end} -->
 
@@ -380,7 +380,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-datastore/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-datastore.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-datastore/2.17.5
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-datastore/2.17.6
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/datastore-v1-proto-client/pom.xml
+++ b/datastore-v1-proto-client/pom.xml
@@ -96,6 +96,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.testparameterinjector</groupId>
+      <artifactId>test-parameter-injector</artifactId>
+      <version>1.14</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <version>1.1.5</version>

--- a/datastore-v1-proto-client/src/main/java/com/google/datastore/v1/client/RemoteRpc.java
+++ b/datastore-v1-proto-client/src/main/java/com/google/datastore/v1/client/RemoteRpc.java
@@ -66,6 +66,25 @@ class RemoteRpc {
   private static boolean enableE2EResponseChecksum =
       Boolean.parseBoolean(System.getenv(E2E_RESPONSE_CHECKSUM_FLAG));
 
+  // Deprecated env var for enabling both request and response checksum.
+  private static final String E2E_CHECKSUM_FLAG_DEPRECATED =
+      "GOOGLE_CLOUD_DATASTORE_HTTP_ENABLE_E2E_CHECKSUM";
+
+  static {
+    if (System.getenv(E2E_CHECKSUM_FLAG_DEPRECATED) != null
+        && System.getenv(E2E_REQUEST_CHECKSUM_FLAG) == null
+        && System.getenv(E2E_RESPONSE_CHECKSUM_FLAG) == null) {
+      logger.warning(
+          String.format(
+              "%s environment variable is deprecated. "
+                  + "Please switch to using %s and/or %s to enable/disable "
+                  + "request and/or response checksum features.",
+              E2E_CHECKSUM_FLAG_DEPRECATED, E2E_REQUEST_CHECKSUM_FLAG, E2E_RESPONSE_CHECKSUM_FLAG));
+      enableE2ERequestChecksum = Boolean.parseBoolean(System.getenv(E2E_CHECKSUM_FLAG_DEPRECATED));
+      enableE2EResponseChecksum = enableE2ERequestChecksum;
+    }
+  }
+
   RemoteRpc(HttpRequestFactory client, HttpRequestInitializer initializer, String url) {
     this.client = client;
     this.initializer = initializer;

--- a/datastore-v1-proto-client/src/test/java/com/google/datastore/v1/client/RemoteRpcTest.java
+++ b/datastore-v1-proto-client/src/test/java/com/google/datastore/v1/client/RemoteRpcTest.java
@@ -177,7 +177,7 @@ public class RemoteRpcTest {
                 EndToEndChecksumHandler.HTTP_RESPONSE_CHECKSUM_HEADER, "invalid_checksum"));
 
     Set<MyHeader> expectedRequestHeaders = new HashSet<>();
-    expectedRequestHeaders.add(MyHeader.AnyValue(RemoteRpc.API_FORMAT_VERSION_HEADER));
+    expectedRequestHeaders.add(MyHeader.anyValue(RemoteRpc.API_FORMAT_VERSION_HEADER));
 
     if (reqEnabled) {
       expectedRequestHeaders.add(
@@ -186,7 +186,7 @@ public class RemoteRpcTest {
               EndToEndChecksumHandler.computeChecksum(request.toByteArray())));
     } else {
       expectedRequestHeaders.add(
-          MyHeader.AnyValue(EndToEndChecksumHandler.HTTP_REQUEST_CHECKSUM_HEADER).mustNotExist());
+          MyHeader.anyValue(EndToEndChecksumHandler.HTTP_REQUEST_CHECKSUM_HEADER).mustNotExist());
     }
 
     InjectedTestValues testVals =
@@ -366,7 +366,7 @@ public class RemoteRpcTest {
     private final boolean ignoreValue;
     private boolean mustExist;
 
-    public static MyHeader AnyValue(String key) {
+    public static MyHeader anyValue(String key) {
       return new MyHeader(key, "", true);
     }
 


### PR DESCRIPTION
This PR replaces the `GOOGLE_CLOUD_DATASTORE_HTTP_ENABLE_E2E_CHECKSUM` flag with two:

- `GOOGLE_CLOUD_DATASTORE_HTTP_ENABLE_E2E_REQUEST_CHECKSUM` - attach payload checksum header to requests (enabled by default)
- `GOOGLE_CLOUD_DATASTORE_HTTP_ENABLE_E2E_RESPONSE_CHECKSUM` - verify response checksum (if extsts in response headers) against response payload and raise IOException if it doesn't match (disabled by default)

And enables the E2E request checksum by default.
This is safe because nobody is using the old flag and we don't reject calls with invalid checksum on the server side yet. But this will provide us the analytics of number of requests with valid/invalid checksums to find edge cases and better prepare for E2E checksum rollout.

The tests for `RemoteRpc` using request and response checksum was also reworked.

Previously the test called the protected `setHeaders` but it does not verify that `RemoteRpc` will call it when making a call. I. e., if in the future we change `RemoteRpc`'s `call` method and remake adding the headers without using the `setHeaders` method then the tests will remain green while necessary headers may not be added.

Instead of calling `setHeaders` from the test itself, we pass the expected headers to the `MyHttpTransport` and make sure the required headers are in place when `MyLowLevelHttpRequest` is doing its `execute` call.

It is easy to convert the remaining test (not related to E2E checksum) that uses `setHeaders` to the same approach, then we can make `setHeaders` private. I can do it in a separate PR if you like.

Another change in the test is that now we verify that checksum in the header is generated correctly (not just checking the length of the checksum string) and verify that the response checksum gets validated.