### PR TITLE
feat!: mark interfaces as `@InternalExtensionOnly`

### DIFF
--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Batch.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Batch.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.datastore;
 
+import com.google.api.core.InternalExtensionOnly;
 import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -42,6 +43,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * This class too should not be treated as a thread safe class. </b>
  */
 @NotThreadSafe
+@InternalExtensionOnly
 public interface Batch extends DatastoreBatchWriter {
 
   interface Response {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Datastore.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Datastore.java
@@ -16,12 +16,14 @@
 
 package com.google.cloud.datastore;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.Service;
 import com.google.datastore.v1.TransactionOptions;
 import java.util.Iterator;
 import java.util.List;
 
 /** An interface for Google Cloud Datastore. */
+@InternalExtensionOnly
 public interface Datastore extends Service<DatastoreOptions>, DatastoreReaderWriter {
 
   /**
@@ -505,7 +507,5 @@ public interface Datastore extends Service<DatastoreOptions>, DatastoreReaderWri
    * @throws DatastoreException upon failure
    * @return {@link AggregationResults}
    */
-  default AggregationResults runAggregation(AggregationQuery query, ReadOption... options) {
-    throw new UnsupportedOperationException("Not implemented.");
-  }
+  AggregationResults runAggregation(AggregationQuery query, ReadOption... options);
 }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreBatchWriter.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreBatchWriter.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.datastore;
 
+import com.google.api.core.InternalExtensionOnly;
 import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -31,6 +32,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * This class too should not be treated as a thread safe class. </b>
  */
 @NotThreadSafe
+@InternalExtensionOnly
 public interface DatastoreBatchWriter extends DatastoreWriter {
 
   /**

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreFactory.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreFactory.java
@@ -16,7 +16,9 @@
 
 package com.google.cloud.datastore;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.ServiceFactory;
 
 /** An interface for Datastore factories. */
+@InternalExtensionOnly
 public interface DatastoreFactory extends ServiceFactory<Datastore, DatastoreOptions> {}

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreReader.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreReader.java
@@ -16,10 +16,12 @@
 
 package com.google.cloud.datastore;
 
+import com.google.api.core.InternalExtensionOnly;
 import java.util.Iterator;
 import java.util.List;
 
 /** An interface to represent Google Cloud Datastore read operations. */
+@InternalExtensionOnly
 public interface DatastoreReader {
 
   /**
@@ -59,7 +61,5 @@ public interface DatastoreReader {
    *
    * @throws DatastoreException upon failure
    */
-  default AggregationResults runAggregation(AggregationQuery query) {
-    throw new UnsupportedOperationException("Not implemented.");
-  }
+  AggregationResults runAggregation(AggregationQuery query);
 }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreReaderWriter.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreReaderWriter.java
@@ -16,5 +16,8 @@
 
 package com.google.cloud.datastore;
 
+import com.google.api.core.InternalExtensionOnly;
+
 /** An interface that combines both Google Cloud Datastore read and write operations. */
+@InternalExtensionOnly
 public interface DatastoreReaderWriter extends DatastoreReader, DatastoreWriter {}

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreWriter.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreWriter.java
@@ -16,9 +16,11 @@
 
 package com.google.cloud.datastore;
 
+import com.google.api.core.InternalExtensionOnly;
 import java.util.List;
 
 /** An interface to represent Google Cloud Datastore write operations. */
+@InternalExtensionOnly
 public interface DatastoreWriter {
 
   /**

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/QueryResults.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/QueryResults.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.datastore;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.datastore.v1.QueryResultBatch;
 import java.util.Iterator;
 
@@ -28,6 +29,7 @@ import java.util.Iterator;
  *
  * @param <V> the type of the results value.
  */
+@InternalExtensionOnly
 public interface QueryResults<V> extends Iterator<V> {
 
   /** Returns the actual class of the result's values. */

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/StructuredQuery.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/StructuredQuery.java
@@ -27,6 +27,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.InternalApi;
+import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.StringEnumType;
 import com.google.cloud.StringEnumValue;
 import com.google.cloud.Timestamp;
@@ -700,6 +701,7 @@ public abstract class StructuredQuery<V> extends Query<V> implements RecordQuery
    *
    * @param <V> the type of result the query returns.
    */
+  @InternalExtensionOnly
   public interface Builder<V> {
 
     /** Sets the namespace for the query. */

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Transaction.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Transaction.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.datastore;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.protobuf.ByteString;
 import java.util.Iterator;
 import java.util.List;
@@ -61,6 +62,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  *     This class too should not be treated as a thread safe class. </b>
  */
 @NotThreadSafe
+@InternalExtensionOnly
 public interface Transaction extends DatastoreBatchWriter, DatastoreReaderWriter {
 
   interface Response {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/ValueBuilder.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/ValueBuilder.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.datastore;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.GcpLaunchStage;
 
 /**
@@ -25,6 +26,7 @@ import com.google.cloud.GcpLaunchStage;
  * @param <P> the value type.
  * @param <B> the value type's associated builder.
  */
+@InternalExtensionOnly
 public interface ValueBuilder<V, P extends Value<V>, B extends ValueBuilder<V, P, B>> {
 
   ValueType getValueType();

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/aggregation/AggregationBuilder.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/aggregation/AggregationBuilder.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.datastore.aggregation;
 
+import com.google.api.core.InternalExtensionOnly;
+
 /**
  * An interface to represent the builders which build and customize {@link Aggregation} for {@link
  * com.google.cloud.datastore.AggregationQuery}.
@@ -23,6 +25,7 @@ package com.google.cloud.datastore.aggregation;
  * <p>Used by {@link
  * com.google.cloud.datastore.AggregationQuery.Builder#addAggregation(AggregationBuilder)}.
  */
+@InternalExtensionOnly
 public interface AggregationBuilder<A extends Aggregation> {
   A build();
 }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/DatastoreRpcFactory.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/DatastoreRpcFactory.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.datastore.spi;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.spi.ServiceRpcFactory;
 
@@ -23,4 +24,5 @@ import com.google.cloud.spi.ServiceRpcFactory;
  * An interface for Datastore RPC factory. Implementation will be loaded via {@link
  * java.util.ServiceLoader}.
  */
+@InternalExtensionOnly
 public interface DatastoreRpcFactory extends ServiceRpcFactory<DatastoreOptions> {}

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/DatastoreRpc.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/DatastoreRpc.java
@@ -17,8 +17,8 @@
 package com.google.cloud.datastore.spi.v1;
 
 import com.google.api.core.InternalApi;
-import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.core.InternalExtensionOnly;
+import com.google.api.gax.rpc.HeaderProvider;
 import com.google.cloud.ServiceRpc;
 import com.google.cloud.datastore.DatastoreException;
 import com.google.cloud.datastore.v1.DatastoreSettings;

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/DatastoreRpc.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/DatastoreRpc.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.datastore.spi.v1;
 
+import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.ServiceRpc;
 import com.google.cloud.datastore.DatastoreException;
 import com.google.datastore.v1.AllocateIdsRequest;
@@ -36,6 +37,7 @@ import com.google.datastore.v1.RunQueryRequest;
 import com.google.datastore.v1.RunQueryResponse;
 
 /** Provides access to the remote Datastore service. */
+@InternalExtensionOnly
 public interface DatastoreRpc extends ServiceRpc {
 
   /**
@@ -93,7 +95,5 @@ public interface DatastoreRpc extends ServiceRpc {
    *
    * @throws DatastoreException upon failure
    */
-  default RunAggregationQueryResponse runAggregationQuery(RunAggregationQueryRequest request) {
-    throw new UnsupportedOperationException("Not implemented.");
-  }
+  RunAggregationQueryResponse runAggregationQuery(RunAggregationQueryRequest request);
 }


### PR DESCRIPTION
Also replaces current `default` methods as they are no longer required.

More details: https://cloud.google.com/java/docs/reference/api-common/latest/com.google.api.core.InternalExtensionOnly