### PR TITLE
feat: use existing transport options API to set transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-datastore'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-datastore:2.17.6'
+implementation 'com.google.cloud:google-cloud-datastore:2.18.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.17.6"
+libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.18.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -380,7 +380,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-datastore/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-datastore.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-datastore/2.17.6
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-datastore/2.18.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -70,7 +70,8 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
         } else if (options.getTransportOptions() instanceof HttpTransportOptions) {
           return new HttpDatastoreRpc(options);
         } else {
-          throw new IllegalArgumentException("unknown transport type: " + options.getTransportOptions());
+          throw new IllegalArgumentException(
+              "unknown transport type: " + options.getTransportOptions());
         }
       } catch (IOException e) {
         throw new RuntimeException(e);

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/DatastoreRpc.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/DatastoreRpc.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.datastore.spi.v1;
 
-import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.HeaderProvider;
 import com.google.cloud.ServiceRpc;
 import com.google.cloud.datastore.DatastoreException;

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/DatastoreRpc.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/DatastoreRpc.java
@@ -117,11 +117,4 @@ public interface DatastoreRpc extends ServiceRpc, AutoCloseable {
       return super.setInternalHeaderProvider(internalHeaderProvider);
     }
   }
-
-  /** Transport used to sending requests. */
-  @InternalApi
-  enum Transport {
-    GRPC,
-    HTTP
-  }
 }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/RemoteDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/RemoteDatastoreHelper.java
@@ -25,6 +25,7 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
+import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.http.HttpTransportOptions;
 import java.util.UUID;
 import org.threeten.bp.Duration;
@@ -81,9 +82,7 @@ public class RemoteDatastoreHelper {
   /** Creates a {@code RemoteStorageHelper} object. */
   @BetaApi
   public static RemoteDatastoreHelper create(String databaseId) {
-    HttpTransportOptions transportOptions = DatastoreOptions.getDefaultHttpTransportOptions();
-    transportOptions =
-        transportOptions.toBuilder().setConnectTimeout(60000).setReadTimeout(60000).build();
+    GrpcTransportOptions transportOptions = DatastoreOptions.getDefaultGrpcTransportOptions();
     DatastoreOptions datastoreOption =
         DatastoreOptions.newBuilder()
             .setDatabaseId(databaseId)

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
@@ -91,12 +91,18 @@ public class DatastoreOptionsTest {
 
     // custom http transport
     DatastoreOptions httpDatastoreOptions =
-        DatastoreOptions.newBuilder().setTransportOptions(HttpTransportOptions.newBuilder().build()).setProjectId(PROJECT_ID).build();
+        DatastoreOptions.newBuilder()
+            .setTransportOptions(HttpTransportOptions.newBuilder().build())
+            .setProjectId(PROJECT_ID)
+            .build();
     assertThat(httpDatastoreOptions.getTransportOptions()).isInstanceOf(HttpTransportOptions.class);
 
     // custom grpc transport
     DatastoreOptions grpcDatastoreOptions =
-        DatastoreOptions.newBuilder().setTransportOptions(GrpcTransportOptions.newBuilder().build()).setProjectId(PROJECT_ID).build();
+        DatastoreOptions.newBuilder()
+            .setTransportOptions(GrpcTransportOptions.newBuilder().build())
+            .setProjectId(PROJECT_ID)
+            .build();
     assertThat(grpcDatastoreOptions.getTransportOptions()).isInstanceOf(GrpcTransportOptions.class);
   }
 

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
@@ -122,15 +122,4 @@ public class DatastoreOptionsTest {
     assertNotEquals(original, newOptions);
     assertNotEquals(original.hashCode(), newOptions.hashCode());
   }
-
-  @Test
-  public void testInvalidTransport() {
-    try {
-      DatastoreOptions.newBuilder()
-          .setTransportOptions(EasyMock.createMock(TransportOptions.class));
-      Assert.fail();
-    } catch (IllegalArgumentException ex) {
-      assertNotNull(ex.getMessage());
-    }
-  }
 }

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.datastore;
 
-import static com.google.cloud.datastore.spi.v1.DatastoreRpc.Transport.GRPC;
-import static com.google.cloud.datastore.spi.v1.DatastoreRpc.Transport.HTTP;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -28,6 +26,8 @@ import static org.junit.Assert.assertTrue;
 import com.google.cloud.TransportOptions;
 import com.google.cloud.datastore.spi.DatastoreRpcFactory;
 import com.google.cloud.datastore.spi.v1.DatastoreRpc;
+import com.google.cloud.grpc.GrpcTransportOptions;
+import com.google.cloud.http.HttpTransportOptions;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
@@ -87,17 +87,17 @@ public class DatastoreOptionsTest {
   @Test
   public void testTransport() {
     // default grpc transport
-    assertThat(options.build().getTransport()).isEqualTo(GRPC);
+    assertThat(options.build().getTransportOptions()).isInstanceOf(GrpcTransportOptions.class);
 
     // custom http transport
     DatastoreOptions httpDatastoreOptions =
-        DatastoreOptions.newBuilder().setTransport(HTTP).setProjectId(PROJECT_ID).build();
-    assertThat(httpDatastoreOptions.getTransport()).isEqualTo(HTTP);
+        DatastoreOptions.newBuilder().setTransportOptions(HttpTransportOptions.newBuilder().build()).setProjectId(PROJECT_ID).build();
+    assertThat(httpDatastoreOptions.getTransportOptions()).isInstanceOf(HttpTransportOptions.class);
 
     // custom grpc transport
     DatastoreOptions grpcDatastoreOptions =
-        DatastoreOptions.newBuilder().setTransport(GRPC).setProjectId(PROJECT_ID).build();
-    assertThat(grpcDatastoreOptions.getTransport()).isEqualTo(GRPC);
+        DatastoreOptions.newBuilder().setTransportOptions(GrpcTransportOptions.newBuilder().build()).setProjectId(PROJECT_ID).build();
+    assertThat(grpcDatastoreOptions.getTransportOptions()).isInstanceOf(GrpcTransportOptions.class);
   }
 
   @Test

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
@@ -19,17 +19,14 @@ package com.google.cloud.datastore;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import com.google.cloud.TransportOptions;
 import com.google.cloud.datastore.spi.DatastoreRpcFactory;
 import com.google.cloud.datastore.spi.v1.DatastoreRpc;
 import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.http.HttpTransportOptions;
 import org.easymock.EasyMock;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
Building on top of https://github.com/googleapis/java-datastore/pull/1261, `setTransportOptions` has always been available as an API to use. Instead of writing custom logic like `setTransport`, we will use the existing API instead and allow it to be set to either gRPC or HTTP.