### PR TITLE
feat: allow setting channel and credential providers in DatastoreOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-datastore'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-datastore:2.18.2'
+implementation 'com.google.cloud:google-cloud-datastore:2.18.3'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.18.2"
+libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.18.3"
 ```
 <!-- {x-version-update-end} -->
 
@@ -380,7 +380,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-datastore/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-datastore.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-datastore/2.18.2
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-datastore/2.18.3
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.29.0')
+implementation platform('com.google.cloud:libraries-bom:26.31.0')
 
 implementation 'com.google.cloud:google-cloud-datastore'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-datastore:2.18.0'
+implementation 'com.google.cloud:google-cloud-datastore:2.18.2'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.18.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.18.2"
 ```
 <!-- {x-version-update-end} -->
 
@@ -380,7 +380,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-datastore/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-datastore.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-datastore/2.18.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-datastore/2.18.2
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -103,7 +103,7 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
       super(options);
       this.namespace = options.namespace;
       this.databaseId = options.databaseId;
-      this.channelProvider = options.channelProvider;
+      this.channelProvider = validateChannelProvider(options.channelProvider);
       this.credentialsProvider = options.credentialsProvider;
     }
 
@@ -119,11 +119,7 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
      *     provider for this client.
      */
     public Builder setChannelProvider(TransportChannelProvider channelProvider) {
-      if (!(channelProvider instanceof InstantiatingGrpcChannelProvider)) {
-        throw new IllegalArgumentException(
-            "Only GRPC channels are allowed for " + API_SHORT_NAME + ".");
-      }
-      this.channelProvider = channelProvider;
+      this.channelProvider = validateChannelProvider(channelProvider);
       return this;
     }
 
@@ -153,6 +149,14 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
       this.databaseId = databaseId;
       return this;
     }
+  }
+
+  private static TransportChannelProvider validateChannelProvider(TransportChannelProvider channelProvider) {
+    if (!(channelProvider instanceof InstantiatingGrpcChannelProvider)) {
+      throw new IllegalArgumentException(
+          "Only GRPC channels are allowed for " + API_SHORT_NAME + ".");
+    }
+    return channelProvider;
   }
 
   private DatastoreOptions(Builder builder) {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -49,8 +49,8 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
   public static final String PROJECT_ID_ENV_VAR = "DATASTORE_PROJECT_ID";
   public static final String LOCAL_HOST_ENV_VAR = "DATASTORE_EMULATOR_HOST";
 
-  private final TransportChannelProvider channelProvider;
-  private final CredentialsProvider credentialsProvider;
+  private final transient TransportChannelProvider channelProvider;
+  private final transient CredentialsProvider credentialsProvider;
 
   private final String namespace;
   private final String databaseId;

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -49,8 +49,8 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
   public static final String PROJECT_ID_ENV_VAR = "DATASTORE_PROJECT_ID";
   public static final String LOCAL_HOST_ENV_VAR = "DATASTORE_EMULATOR_HOST";
 
-  private final transient TransportChannelProvider channelProvider;
-  private final transient CredentialsProvider credentialsProvider;
+  private transient TransportChannelProvider channelProvider = null;
+  private transient CredentialsProvider credentialsProvider = null;
 
   private final String namespace;
   private final String databaseId;
@@ -101,8 +101,8 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
 
     private Builder(DatastoreOptions options) {
       super(options);
-      namespace = options.namespace;
-      databaseId = options.databaseId;
+      this.namespace = options.namespace;
+      this.databaseId = options.databaseId;
       this.channelProvider = options.channelProvider;
       this.credentialsProvider = options.credentialsProvider;
     }
@@ -165,7 +165,7 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
         && (builder.channelProvider != null || builder.credentialsProvider != null)) {
       throw new IllegalArgumentException(
           "Only gRPC transport allows setting of channel provider or credentials provider");
-    } else {
+    } else if (getTransportOptions() instanceof GrpcTransportOptions) {
       this.channelProvider =
           builder.channelProvider != null
               ? builder.channelProvider

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -160,16 +160,23 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
     namespace = MoreObjects.firstNonNull(builder.namespace, defaultNamespace());
     databaseId = MoreObjects.firstNonNull(builder.databaseId, DEFAULT_DATABASE_ID);
 
-    this.channelProvider =
-        builder.channelProvider != null
-            ? builder.channelProvider
-            : GrpcTransportOptions.setUpChannelProvider(
-                DatastoreSettings.defaultGrpcTransportProviderBuilder(), this);
+    // todo see if we can update this
+    if (getTransportOptions() instanceof HttpTransportOptions
+        && (builder.channelProvider != null || builder.credentialsProvider != null)) {
+      throw new IllegalArgumentException(
+          "Only gRPC transport allows setting of channel provider or credentials provider");
+    } else {
+      this.channelProvider =
+          builder.channelProvider != null
+              ? builder.channelProvider
+              : GrpcTransportOptions.setUpChannelProvider(
+                  DatastoreSettings.defaultGrpcTransportProviderBuilder(), this);
 
-    this.credentialsProvider =
-        builder.credentialsProvider != null
-            ? builder.credentialsProvider
-            : GrpcTransportOptions.setUpCredentialsProvider(this);
+      this.credentialsProvider =
+          builder.credentialsProvider != null
+              ? builder.credentialsProvider
+              : GrpcTransportOptions.setUpCredentialsProvider(this);
+    }
   }
 
   public CredentialsProvider getCredentialsProvider() {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -151,7 +151,8 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
     }
   }
 
-  private static TransportChannelProvider validateChannelProvider(TransportChannelProvider channelProvider) {
+  private static TransportChannelProvider validateChannelProvider(
+      TransportChannelProvider channelProvider) {
     if (!(channelProvider instanceof InstantiatingGrpcChannelProvider)) {
       throw new IllegalArgumentException(
           "Only GRPC channels are allowed for " + API_SHORT_NAME + ".");

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -18,6 +18,9 @@ package com.google.cloud.datastore;
 
 import static com.google.cloud.datastore.Validator.validateNamespace;
 
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.ServiceDefaults;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.ServiceRpc;
@@ -46,6 +49,9 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
   public static final String PROJECT_ID_ENV_VAR = "DATASTORE_PROJECT_ID";
   public static final String LOCAL_HOST_ENV_VAR = "DATASTORE_EMULATOR_HOST";
 
+  private final TransportChannelProvider channelProvider;
+  private final CredentialsProvider credentialsProvider;
+
   private final String namespace;
   private final String databaseId;
 
@@ -69,6 +75,10 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
         if (options.getTransportOptions() instanceof GrpcTransportOptions) {
           return new GrpcDatastoreRpc(options);
         } else if (options.getTransportOptions() instanceof HttpTransportOptions) {
+          // todo see if we can remove this check
+          if (DatastoreUtils.isEmulator(options)) {
+            throw new IllegalArgumentException("Only GRPC channels are allowed for emulator.");
+          }
           return new HttpDatastoreRpc(options);
         } else {
           throw new IllegalArgumentException(
@@ -84,6 +94,8 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
 
     private String namespace;
     private String databaseId;
+    private TransportChannelProvider channelProvider = null;
+    private CredentialsProvider credentialsProvider = null;
 
     private Builder() {}
 
@@ -91,11 +103,39 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
       super(options);
       namespace = options.namespace;
       databaseId = options.databaseId;
+      this.channelProvider = options.channelProvider;
+      this.credentialsProvider = options.credentialsProvider;
     }
 
     @Override
     public Builder setTransportOptions(TransportOptions transportOptions) {
       return super.setTransportOptions(transportOptions);
+    }
+
+    /**
+     * Sets the {@link TransportChannelProvider} to use with this Datastore client.
+     *
+     * @param channelProvider A InstantiatingGrpcChannelProvider object that defines the transport
+     *     provider for this client.
+     */
+    public Builder setChannelProvider(TransportChannelProvider channelProvider) {
+      if (!(channelProvider instanceof InstantiatingGrpcChannelProvider)) {
+        throw new IllegalArgumentException(
+            "Only GRPC channels are allowed for " + API_SHORT_NAME + ".");
+      }
+      this.channelProvider = channelProvider;
+      return this;
+    }
+
+    /**
+     * Sets the {@link CredentialsProvider} to use with this Datastore client.
+     *
+     * @param credentialsProvider A CredentialsProvider object that defines the credential provider
+     *     for this client.
+     */
+    public Builder setCredentialsProvider(CredentialsProvider credentialsProvider) {
+      this.credentialsProvider = credentialsProvider;
+      return this;
     }
 
     @Override
@@ -119,6 +159,25 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
     super(DatastoreFactory.class, DatastoreRpcFactory.class, builder, new DatastoreDefaults());
     namespace = MoreObjects.firstNonNull(builder.namespace, defaultNamespace());
     databaseId = MoreObjects.firstNonNull(builder.databaseId, DEFAULT_DATABASE_ID);
+
+    this.channelProvider =
+        builder.channelProvider != null
+            ? builder.channelProvider
+            : GrpcTransportOptions.setUpChannelProvider(
+                DatastoreSettings.defaultGrpcTransportProviderBuilder(), this);
+
+    this.credentialsProvider =
+        builder.credentialsProvider != null
+            ? builder.credentialsProvider
+            : GrpcTransportOptions.setUpCredentialsProvider(this);
+  }
+
+  public CredentialsProvider getCredentialsProvider() {
+    return credentialsProvider;
+  }
+
+  public TransportChannelProvider getTransportChannelProvider() {
+    return channelProvider;
   }
 
   @Override
@@ -134,6 +193,7 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
   }
 
   private static class DatastoreDefaults implements ServiceDefaults<Datastore, DatastoreOptions> {
+    private final TransportOptions TRANSPORT_OPTIONS = getDefaultTransportOptionsBuilder().build();
 
     @Override
     public DatastoreFactory getDefaultServiceFactory() {
@@ -147,7 +207,11 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
 
     @Override
     public TransportOptions getDefaultTransportOptions() {
-      return getDefaultGrpcTransportOptions();
+      return TRANSPORT_OPTIONS;
+    }
+
+    public static GrpcTransportOptions.Builder getDefaultTransportOptionsBuilder() {
+      return GrpcTransportOptions.newBuilder();
     }
   }
 
@@ -202,7 +266,7 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
 
   @Override
   public int hashCode() {
-    return Objects.hash(baseHashCode(), namespace, databaseId);
+    return Objects.hash(baseHashCode(), namespace, databaseId, channelProvider);
   }
 
   @Override
@@ -213,6 +277,7 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
     DatastoreOptions other = (DatastoreOptions) obj;
     return baseEquals(other)
         && Objects.equals(namespace, other.namespace)
+        && Objects.equals(channelProvider, other.channelProvider)
         && Objects.equals(databaseId, other.databaseId);
   }
 

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -273,7 +273,7 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
 
   @Override
   public int hashCode() {
-    return Objects.hash(baseHashCode(), namespace, databaseId, channelProvider);
+    return Objects.hash(baseHashCode(), namespace, databaseId);
   }
 
   @Override
@@ -284,7 +284,6 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
     DatastoreOptions other = (DatastoreOptions) obj;
     return baseEquals(other)
         && Objects.equals(namespace, other.namespace)
-        && Objects.equals(channelProvider, other.channelProvider)
         && Objects.equals(databaseId, other.databaseId);
   }
 

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreUtils.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreUtils.java
@@ -17,12 +17,18 @@
 package com.google.cloud.datastore;
 
 import com.google.api.core.InternalApi;
+import com.google.cloud.NoCredentials;
 import com.google.common.base.Strings;
 import java.net.InetAddress;
 import java.net.URL;
 
 @InternalApi
 public class DatastoreUtils {
+
+  public static boolean isEmulator(DatastoreOptions datastoreOptions) {
+    return isLocalHost(datastoreOptions.getHost())
+        || NoCredentials.getInstance().equals(datastoreOptions.getCredentials());
+  }
 
   public static boolean isLocalHost(String host) {
     if (Strings.isNullOrEmpty(host)) {

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
@@ -32,6 +32,7 @@ import com.google.cloud.datastore.v1.DatastoreSettings;
 import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.http.HttpTransportOptions;
 import org.easymock.EasyMock;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -111,6 +112,20 @@ public class DatastoreOptionsTest {
     DatastoreOptions datastoreOptions = options2.build();
     assertEquals(datastoreOptions.getTransportChannelProvider(), channelProvider);
     assertEquals(datastoreOptions.getCredentialsProvider(), noCredentialsProvider);
+  }
+
+  @Test
+  public void testInvalidConfigForHttp() {
+    DatastoreOptions.Builder options =
+        DatastoreOptions.newBuilder()
+            .setServiceRpcFactory(datastoreRpcFactory)
+            .setProjectId(PROJECT_ID)
+            .setDatabaseId(DATABASE_ID)
+            .setTransportOptions(HttpTransportOptions.newBuilder().build())
+            .setChannelProvider(channelProvider)
+            .setCredentialsProvider(noCredentialsProvider)
+            .setHost("http://localhost:" + PORT);
+    Assert.assertThrows(IllegalArgumentException.class, options::build);
   }
 
   @Test

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/SerializationTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/SerializationTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.datastore;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.cloud.BaseSerializationTest;
-import com.google.cloud.NoCredentials;
 import com.google.cloud.Restorable;
 import com.google.cloud.Timestamp;
 import com.google.cloud.datastore.StructuredQuery.CompositeFilter;

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/SerializationTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/SerializationTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.datastore;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.cloud.BaseSerializationTest;
+import com.google.cloud.NoCredentials;
 import com.google.cloud.Restorable;
 import com.google.cloud.Timestamp;
 import com.google.cloud.datastore.StructuredQuery.CompositeFilter;
@@ -124,6 +125,12 @@ public class SerializationTest extends BaseSerializationTest {
 
   @Override
   protected java.io.Serializable[] serializableObjects() {
+    DatastoreOptions options =
+        DatastoreOptions.newBuilder()
+            .setCredentials(NoCredentials.getInstance())
+            .setProjectId("ds1")
+            .build();
+    DatastoreOptions otherOptions = options.toBuilder().setNamespace("ns1").build();
     return new java.io.Serializable[] {
       KEY1,
       KEY2,
@@ -157,7 +164,9 @@ public class SerializationTest extends BaseSerializationTest {
       BLOB_VALUE,
       RAW_VALUE,
       LAT_LNG_VALUE,
-      DATASTORE_EXCEPTION
+      DATASTORE_EXCEPTION,
+      options,
+      otherOptions
     };
   }
 

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/SerializationTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/SerializationTest.java
@@ -125,12 +125,6 @@ public class SerializationTest extends BaseSerializationTest {
 
   @Override
   protected java.io.Serializable[] serializableObjects() {
-    DatastoreOptions options =
-        DatastoreOptions.newBuilder()
-            .setCredentials(NoCredentials.getInstance())
-            .setProjectId("ds1")
-            .build();
-    DatastoreOptions otherOptions = options.toBuilder().setNamespace("ns1").build();
     return new java.io.Serializable[] {
       KEY1,
       KEY2,
@@ -164,9 +158,7 @@ public class SerializationTest extends BaseSerializationTest {
       BLOB_VALUE,
       RAW_VALUE,
       LAT_LNG_VALUE,
-      DATASTORE_EXCEPTION,
-      options,
-      otherOptions
+      DATASTORE_EXCEPTION
     };
   }
 


### PR DESCRIPTION
Similar to Firestore, https://github.com/googleapis/java-firestore/blob/main/google-cloud-firestore/src/main/java/com/google/cloud/firestore/FirestoreOptions.java#L162-L168, this allows users to configure more custom options available in gax and gRPC like credentials providers and channel pooling.