### PR TITLE
chore: next release from main branch is 2.18.0

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -26,3 +26,7 @@ branches:
     handleGHRelease: true
     releaseType: java-backport
     branch: 2.15.x
+  - bumpMinorPreMajor: true
+    handleGHRelease: true
+    releaseType: java-backport
+    branch: 2.17.x

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -145,6 +145,23 @@ branchProtectionRules:
       - OwlBot Post Processor
       - 'Kokoro - Test: Java GraalVM Native Image'
       - 'Kokoro - Test: Java 17 GraalVM Native Image'
+  - pattern: 2.17.x
+    isAdminEnforced: true
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: false
+    requiredStatusCheckContexts:
+      - dependencies (17)
+      - lint
+      - clirr
+      - units (8)
+      - units (11)
+      - 'Kokoro - Test: Integration'
+      - cla/google
+      - OwlBot Post Processor
+      - 'Kokoro - Test: Java GraalVM Native Image'
+      - 'Kokoro - Test: Java 17 GraalVM Native Image'
+      - javadoc
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
chore: enable branch protection for 2.17.x branch
END_COMMIT_OVERRIDE
enable releases