### PR TITLE
chore: include recommended_package in repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -15,5 +15,6 @@
   "api_description": "is a fully managed, schemaless database for\nstoring non-relational data. Cloud Datastore automatically scales with\nyour users and supports ACID transactions, high availability of reads and\nwrites, strong consistency for reads and ancestor queries, and eventual\nconsistency for all other queries.",
   "excluded_dependencies": "grpc-google-cloud-datastore-v1",
   "extra_versioned_modules": "datastore-v1-proto-client",
-  "excluded_poms": "grpc-google-cloud-datastore-v1"
+  "excluded_poms": "grpc-google-cloud-datastore-v1",
+  "recommended_package": "com.google.cloud.datastore"
 }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.35.0')
+implementation platform('com.google.cloud:libraries-bom:26.36.0')
 
 implementation 'com.google.cloud:google-cloud-datastore'
 ```


### PR DESCRIPTION
Adds a field for `recommended_package` as part of the revamped Library Overviews.
See go/cloud-rad-overviews-handwritten-repos for more details