### PR TITLE
feat: RunAggregationQuery instrumentation

### DIFF
--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
@@ -242,7 +242,7 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
   com.google.datastore.v1.RunQueryResponse runQuery(
       final com.google.datastore.v1.RunQueryRequest requestPb) {
     com.google.cloud.datastore.telemetry.TraceUtil.Span span =
-        otelTraceUtil.startSpan(com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUNQUERY);
+        otelTraceUtil.startSpan(com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUN_QUERY);
     ReadOptions readOptions = requestPb.getReadOptions();
     span.setAttribute(
         "isTransactional", readOptions.hasTransaction() || readOptions.hasNewTransaction());
@@ -258,7 +258,7 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
                   : TRANSACTION_OPERATION_EXCEPTION_HANDLER,
               getOptions().getClock());
       span.addEvent(
-          com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUNQUERY + ": Completed",
+          com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUN_QUERY + ": Completed",
           new ImmutableMap.Builder<String, Object>()
               .put("Received", response.getBatch().getEntityResultsCount())
               .put("More results", response.getBatch().getMoreResults().toString())

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Sets;
 import com.google.datastore.v1.ExplainOptions;
 import com.google.datastore.v1.ReadOptions;
 import com.google.datastore.v1.ReserveIdsRequest;
+import com.google.datastore.v1.RunQueryResponse;
 import com.google.datastore.v1.TransactionOptions;
 import com.google.protobuf.ByteString;
 import io.opencensus.common.Scope;
@@ -240,20 +241,34 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
 
   com.google.datastore.v1.RunQueryResponse runQuery(
       final com.google.datastore.v1.RunQueryRequest requestPb) {
-    Span span = traceUtil.startSpan(TraceUtil.SPAN_NAME_RUNQUERY);
-    try (Scope scope = traceUtil.getTracer().withSpan(span)) {
-      return RetryHelper.runWithRetries(
-          () -> datastoreRpc.runQuery(requestPb),
-          retrySettings,
-          requestPb.getReadOptions().getTransaction().isEmpty()
-              ? EXCEPTION_HANDLER
-              : TRANSACTION_OPERATION_EXCEPTION_HANDLER,
-          getOptions().getClock());
+    com.google.cloud.datastore.telemetry.TraceUtil.Span span =
+        otelTraceUtil.startSpan(com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUNQUERY);
+    ReadOptions readOptions = requestPb.getReadOptions();
+    span.setAttribute(
+        "isTransactional", readOptions.hasTransaction() || readOptions.hasNewTransaction());
+    span.setAttribute("readConsistency", readOptions.getReadConsistency().toString());
+
+    try (com.google.cloud.datastore.telemetry.TraceUtil.Scope ignored = span.makeCurrent()) {
+      RunQueryResponse response =
+          RetryHelper.runWithRetries(
+              () -> datastoreRpc.runQuery(requestPb),
+              retrySettings,
+              requestPb.getReadOptions().getTransaction().isEmpty()
+                  ? EXCEPTION_HANDLER
+                  : TRANSACTION_OPERATION_EXCEPTION_HANDLER,
+              getOptions().getClock());
+      span.addEvent(
+          com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUNQUERY + ": Completed",
+          new ImmutableMap.Builder<String, Object>()
+              .put("Received", response.getBatch().getEntityResultsCount())
+              .put("More results", response.getBatch().getMoreResults().toString())
+              .build());
+      return response;
     } catch (RetryHelperException e) {
-      span.setStatus(Status.UNKNOWN.withDescription(e.getMessage()));
+      span.end(e);
       throw DatastoreException.translateAndThrow(e);
     } finally {
-      span.end(TraceUtil.END_SPAN_OPTIONS);
+      span.end();
     }
   }
 

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
@@ -31,9 +31,7 @@ public interface TraceUtil {
   static final String ATTRIBUTE_SERVICE_PREFIX = "gcp.datastore.";
   static final String ENABLE_TRACING_ENV_VAR = "DATASTORE_ENABLE_TRACING";
   static final String LIBRARY_NAME = "com.google.cloud.datastore";
-
   static final String SPAN_NAME_LOOKUP = "Lookup";
-  
   static final String SPAN_NAME_RUNQUERY = "RunQuery";
 
   /**

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
@@ -33,6 +33,9 @@ public interface TraceUtil {
   static final String LIBRARY_NAME = "com.google.cloud.datastore";
 
   static final String SPAN_NAME_LOOKUP = "Lookup";
+  
+  static final String SPAN_NAME_RUNQUERY = "RunQuery";
+
   /**
    * Creates and returns an instance of the TraceUtil class.
    *

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
@@ -32,7 +32,7 @@ public interface TraceUtil {
   static final String ENABLE_TRACING_ENV_VAR = "DATASTORE_ENABLE_TRACING";
   static final String LIBRARY_NAME = "com.google.cloud.datastore";
   static final String SPAN_NAME_LOOKUP = "Lookup";
-  static final String SPAN_NAME_RUNQUERY = "RunQuery";
+  static final String SPAN_NAME_RUN_QUERY = "RunQuery";
 
   /**
    * Creates and returns an instance of the TraceUtil class.

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
@@ -33,6 +33,7 @@ public interface TraceUtil {
   static final String LIBRARY_NAME = "com.google.cloud.datastore";
   static final String SPAN_NAME_LOOKUP = "Lookup";
   static final String SPAN_NAME_RUN_QUERY = "RunQuery";
+  static final String SPAN_NAME_RUN_AGGREGATION_QUERY = "RunAggregationQuery";
 
   /**
    * Creates and returns an instance of the TraceUtil class.

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/RetryAndTraceDatastoreRpcDecoratorTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/RetryAndTraceDatastoreRpcDecoratorTest.java
@@ -19,7 +19,6 @@ import static com.google.cloud.datastore.TraceUtil.END_SPAN_OPTIONS;
 import static com.google.cloud.datastore.TraceUtil.SPAN_NAME_RUN_AGGREGATION_QUERY;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.rpc.Code.UNAVAILABLE;
-import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.createStrictMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -29,8 +28,7 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.datastore.spi.v1.DatastoreRpc;
 import com.google.datastore.v1.RunAggregationQueryRequest;
 import com.google.datastore.v1.RunAggregationQueryResponse;
-import io.opencensus.trace.Span;
-import io.opencensus.trace.Tracer;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,7 +47,6 @@ public class RetryAndTraceDatastoreRpcDecoratorTest {
   @Before
   public void setUp() throws Exception {
     mockDatastoreRpc = createStrictMock(DatastoreRpc.class);
-    mockTraceUtil = createStrictMock(TraceUtil.class);
     datastoreRpcDecorator =
         new RetryAndTraceDatastoreRpcDecorator(
             mockDatastoreRpc, mockTraceUtil, retrySettings, datastoreOptions);
@@ -57,7 +54,6 @@ public class RetryAndTraceDatastoreRpcDecoratorTest {
 
   @Test
   public void testRunAggregationQuery() {
-    Span mockSpan = createStrictMock(Span.class);
     RunAggregationQueryRequest aggregationQueryRequest =
         RunAggregationQueryRequest.getDefaultInstance();
     RunAggregationQueryResponse aggregationQueryResponse =
@@ -69,16 +65,13 @@ public class RetryAndTraceDatastoreRpcDecoratorTest {
                 UNAVAILABLE.getNumber(), "API not accessible currently", UNAVAILABLE.name()))
         .times(2)
         .andReturn(aggregationQueryResponse);
-    expect(mockTraceUtil.startSpan(SPAN_NAME_RUN_AGGREGATION_QUERY)).andReturn(mockSpan);
-    expect(mockTraceUtil.getTracer()).andReturn(createNiceMock(Tracer.class));
-    mockSpan.end(END_SPAN_OPTIONS);
 
-    replay(mockDatastoreRpc, mockTraceUtil, mockSpan);
+    replay(mockDatastoreRpc);
 
     RunAggregationQueryResponse actualAggregationQueryResponse =
         datastoreRpcDecorator.runAggregationQuery(aggregationQueryRequest);
 
     assertThat(actualAggregationQueryResponse).isSameInstanceAs(aggregationQueryResponse);
-    verify(mockDatastoreRpc, mockTraceUtil, mockSpan);
+    verify(mockDatastoreRpc);
   }
 }

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/RetryAndTraceDatastoreRpcDecoratorTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/RetryAndTraceDatastoreRpcDecoratorTest.java
@@ -15,8 +15,6 @@
  */
 package com.google.cloud.datastore;
 
-import static com.google.cloud.datastore.TraceUtil.END_SPAN_OPTIONS;
-import static com.google.cloud.datastore.TraceUtil.SPAN_NAME_RUN_AGGREGATION_QUERY;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.rpc.Code.UNAVAILABLE;
 import static org.easymock.EasyMock.createStrictMock;
@@ -28,7 +26,6 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.datastore.spi.v1.DatastoreRpc;
 import com.google.datastore.v1.RunAggregationQueryRequest;
 import com.google.datastore.v1.RunAggregationQueryResponse;
-
 import org.junit.Before;
 import org.junit.Test;
 

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
@@ -631,6 +631,7 @@ public class ITE2ETracingTest {
     fetchAndValidateTrace(customSpanContext.getTraceId(), SPAN_NAME_COMMIT);
   }
 
+  @Test
   public void runQueryTraceTest() throws Exception {
  Entity entity1 = Entity.newBuilder(KEY1).set("test_field", "test_value1").build();
     Entity entity2 = Entity.newBuilder(KEY2).set("test_field", "test_value2").build();

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
@@ -244,8 +244,9 @@ public class ITE2ETracingTest {
   @TestParameter boolean useGlobalOpenTelemetrySDK;
 
   @TestParameter({
-      /*(default)*/
-    "", "test-db"
+    /*(default)*/
+    "",
+    "test-db"
   })
   String datastoreNamedDatabase;
 

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
@@ -652,7 +652,7 @@ public class ITE2ETracingTest {
 
   @Test
   public void runQueryTraceTest() throws Exception {
- Entity entity1 = Entity.newBuilder(KEY1).set("test_field", "test_value1").build();
+    Entity entity1 = Entity.newBuilder(KEY1).set("test_field", "test_value1").build();
     Entity entity2 = Entity.newBuilder(KEY2).set("test_field", "test_value2").build();
     List<Entity> entityList = new ArrayList<>();
     entityList.add(entity1);

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
@@ -17,7 +17,7 @@
 package com.google.cloud.datastore.it;
 
 import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_LOOKUP;
-import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUNQUERY;
+import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUN_QUERY;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -572,6 +572,6 @@ public class ITE2ETracingTest {
     }
     waitForTracesToComplete();
 
-    fetchAndValidateTrace(customSpanContext.getTraceId(), SPAN_NAME_RUNQUERY);
+    fetchAndValidateTrace(customSpanContext.getTraceId(), SPAN_NAME_RUN_QUERY);
   }
 }


### PR DESCRIPTION
- Added tracing instrumentation and test for `runAggregationQuery` operation.
- Retired open census instrumentation and test expectations
- Will add hermetic integration tests using OpenTelemetry InMemorySpanExporter in a future CL (after all RPCs have been tested E2E) to replace the verification in [RetryAndTraceDatastoreRpcDecorator.java](https://github.com/googleapis/java-datastore/compare/jimit/runquery-trace-1...jimit/aggreagationquery-trace-2?expand=1#diff-4cb6c345a84183cb9ef45660185616e0049120a63bcc1582516c423d4a652009).

Fixes #1428  ☕️

