### PR TITLE
fix: Migrate off TextPrinter's deprecated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-datastore'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-datastore:2.19.2'
+implementation 'com.google.cloud:google-cloud-datastore:2.19.3'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.19.2"
+libraryDependencies += "com.google.cloud" % "google-cloud-datastore" % "2.19.3"
 ```
 <!-- {x-version-update-end} -->
 
@@ -384,7 +384,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-datastore/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-datastore.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-datastore/2.19.2
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-datastore/2.19.3
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Key.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Key.java
@@ -145,7 +145,7 @@ public final class Key extends IncompleteKey {
   /** Returns the key in an encoded form that can be used as part of a URL. */
   public String toUrlSafe() {
     try {
-      return URLEncoder.encode(TextFormat.printToString(toPb()), UTF_8.name());
+      return URLEncoder.encode(TextFormat.printer().printToString(toPb()), UTF_8.name());
     } catch (UnsupportedEncodingException e) {
       throw new IllegalStateException("Unexpected encoding exception", e);
     }


### PR DESCRIPTION
Fixes: https://github.com/googleapis/java-datastore/issues/1450