### PR TITLE
fix: set the correct database id on the key parent when calling Key#getParent

### DIFF
--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/IncompleteKey.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/IncompleteKey.java
@@ -91,9 +91,11 @@ public class IncompleteKey extends BaseKey {
     PathElement parent = ancestors.get(ancestors.size() - 1);
     Key.Builder keyBuilder;
     if (parent.hasName()) {
-      keyBuilder = Key.newBuilder(getProjectId(), parent.getKind(), parent.getName(), getDatabaseId());
+      keyBuilder =
+          Key.newBuilder(getProjectId(), parent.getKind(), parent.getName(), getDatabaseId());
     } else {
-      keyBuilder = Key.newBuilder(getProjectId(), parent.getKind(), parent.getId(), getDatabaseId());
+      keyBuilder =
+          Key.newBuilder(getProjectId(), parent.getKind(), parent.getId(), getDatabaseId());
     }
     String namespace = getNamespace();
     if (namespace != null) {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/IncompleteKey.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/IncompleteKey.java
@@ -91,9 +91,9 @@ public class IncompleteKey extends BaseKey {
     PathElement parent = ancestors.get(ancestors.size() - 1);
     Key.Builder keyBuilder;
     if (parent.hasName()) {
-      keyBuilder = Key.newBuilder(getProjectId(), parent.getKind(), parent.getName());
+      keyBuilder = Key.newBuilder(getProjectId(), parent.getKind(), parent.getName(), getDatabaseId());
     } else {
-      keyBuilder = Key.newBuilder(getProjectId(), parent.getKind(), parent.getId());
+      keyBuilder = Key.newBuilder(getProjectId(), parent.getKind(), parent.getId(), getDatabaseId());
     }
     String namespace = getNamespace();
     if (namespace != null) {

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/IncompleteKeyTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/IncompleteKeyTest.java
@@ -25,15 +25,17 @@ import org.junit.Test;
 
 public class IncompleteKeyTest {
 
-  private static IncompleteKey pk1, pk2, pk4;
-  private static Key parent1;
+  private static IncompleteKey pk1, pk2, pk4, pk5;
+  private static Key parent1, parent2;
 
   @Before
   public void setUp() {
     pk1 = IncompleteKey.newBuilder("ds", "kind1").build();
     parent1 = Key.newBuilder("ds", "kind2", 10).setNamespace("ns").build();
+    parent2 = Key.newBuilder("ds", "kind2", 10, "test-db").setNamespace("ns").build();
     pk2 = IncompleteKey.newBuilder(parent1, "kind3").build();
     pk4 = IncompleteKey.newBuilderWithDatabaseId("ds", "kind3", "test-db").build();
+    pk5 = IncompleteKey.newBuilder(parent2, "kind4").build();
   }
 
   @Test
@@ -59,12 +61,18 @@ public class IncompleteKeyTest {
     assertEquals("test-db", pk4.getDatabaseId());
     assertEquals("kind3", pk4.getKind());
     assertTrue(pk4.getAncestors().isEmpty());
+
+    assertEquals("ds", pk5.getProjectId());
+    assertEquals("test-db", pk5.getDatabaseId());
+    assertEquals("kind4", pk5.getKind());
+    assertEquals(parent2.getPath(), pk5.getAncestors());
   }
 
   @Test
   public void testParent() {
     assertNull(pk1.getParent());
     assertEquals(parent1, pk2.getParent());
+    assertEquals(parent2, pk5.getParent());
     Key parent2 = Key.newBuilder("ds", "kind3", "name").setNamespace("ns").build();
     IncompleteKey pk3 = IncompleteKey.newBuilder(parent2, "kind3").build();
     assertEquals(parent2, pk3.getParent());


### PR DESCRIPTION
Fixes #1456 ☕️

This is to fix the bug where the database ID is not set correctly on the parent key. The bug causes problems in Objectify by preventing you from fetching an entity from a non-default database, using a parent key.