### PR TITLE
fix: Fixed Span nesting for `ReadWriteTransactionCallable` by using parent SpanContext instead of just parent Context

### DIFF
--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
@@ -143,7 +143,7 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
       options = options.toBuilder().setReadWrite(readWrite).build();
     }
 
-    private io.opentelemetry.api.trace.Span startSpanInternal(
+    private io.opentelemetry.api.trace.Span startSpanWithParentContext(
         String spanName,
         com.google.cloud.datastore.telemetry.TraceUtil.SpanContext parentSpanContext) {
       com.google.cloud.datastore.telemetry.TraceUtil otelTraceUtil =
@@ -169,7 +169,7 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
       // debugging. The code below works and is idiomatic but could be prettier and more consistent
       // with the use of TraceUtil-provided framework.
       io.opentelemetry.api.trace.Span span =
-          startSpanInternal(
+          startSpanWithParentContext(
               com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN,
               parentSpanContext);
       try (io.opentelemetry.context.Scope ignored = span.makeCurrent()) {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
@@ -27,6 +27,7 @@ import com.google.cloud.datastore.execution.AggregationQueryExecutor;
 import com.google.cloud.datastore.spi.v1.DatastoreRpc;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -41,7 +42,10 @@ import com.google.protobuf.ByteString;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
-import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,7 +55,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -108,13 +111,13 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
     private volatile TransactionOptions options;
     private volatile Transaction transaction;
 
-    private final SpanContext parentSpanContext;
+    private final com.google.cloud.datastore.telemetry.TraceUtil.SpanContext parentSpanContext;
 
     ReadWriteTransactionCallable(
         Datastore datastore,
         TransactionCallable<T> callable,
         TransactionOptions options,
-        @Nullable SpanContext parentSpanContext) {
+        @Nullable com.google.cloud.datastore.telemetry.TraceUtil.SpanContext parentSpanContext) {
       this.datastore = datastore;
       this.callable = callable;
       this.options = options;
@@ -140,17 +143,35 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
       options = options.toBuilder().setReadWrite(readWrite).build();
     }
 
+    private io.opentelemetry.api.trace.Span startSpanInternal(
+        String spanName,
+        com.google.cloud.datastore.telemetry.TraceUtil.SpanContext parentSpanContext) {
+      com.google.cloud.datastore.telemetry.TraceUtil otelTraceUtil =
+          datastore.getOptions().getTraceUtil();
+      SpanBuilder spanBuilder =
+          otelTraceUtil
+              .getTracer()
+              .spanBuilder(com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN)
+              .setSpanKind(SpanKind.PRODUCER)
+              .setParent(
+                  Context.current()
+                      .with(
+                          io.opentelemetry.api.trace.Span.wrap(
+                              parentSpanContext.getSpanContext())));
+      return spanBuilder.startSpan();
+    }
+
     @Override
     public T call() throws DatastoreException {
+      // TODO Instead of using OTel Spans directly, TraceUtil.Span should be used here. However,
+      // the same code in startSpanInternal doesn't work when EnabledTraceUtil.StartSpan is called
+      // probably because of some thread-local caching that is getting lost. This needs more
+      // debugging. The code below works and is idiomatic but could be prettier and more consistent
+      // with the use of TraceUtil-provided framework.
       io.opentelemetry.api.trace.Span span =
-          Objects.requireNonNull(
-                  datastore.getOptions().getOpenTelemetryOptions().getOpenTelemetry())
-              .getTracer(com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN)
-              .spanBuilder(com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN)
-              .setParent(
-                  Context.current().with(io.opentelemetry.api.trace.Span.wrap(parentSpanContext)))
-              .startSpan();
-
+          startSpanInternal(
+              com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN,
+              parentSpanContext);
       try (io.opentelemetry.context.Scope ignored = span.makeCurrent()) {
         transaction = datastore.newTransaction(options);
         T value = callable.run(transaction);
@@ -158,6 +179,14 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
         return value;
       } catch (Exception ex) {
         transaction.rollback();
+        span.setStatus(StatusCode.ERROR, ex.getMessage());
+        span.recordException(
+            ex,
+            Attributes.builder()
+                .put("exception.message", ex.getMessage())
+                .put("exception.type", ex.getClass().getName())
+                .put("exception.stacktrace", Throwables.getStackTraceAsString(ex))
+                .build());
         span.end();
         throw DatastoreException.propagateUserException(ex);
       } finally {
@@ -178,7 +207,7 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
     try {
       return RetryHelper.runWithRetries(
           new ReadWriteTransactionCallable<T>(
-              this, callable, null, io.opentelemetry.api.trace.Span.current().getSpanContext()),
+              this, callable, null, otelTraceUtil.getCurrentSpanContext()),
           retrySettings,
           TRANSACTION_EXCEPTION_HANDLER,
           getOptions().getClock());
@@ -193,10 +222,7 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
     try {
       return RetryHelper.runWithRetries(
           new ReadWriteTransactionCallable<T>(
-              this,
-              callable,
-              transactionOptions,
-              io.opentelemetry.api.trace.Span.current().getSpanContext()),
+              this, callable, transactionOptions, otelTraceUtil.getCurrentSpanContext()),
           retrySettings,
           TRANSACTION_EXCEPTION_HANDLER,
           getOptions().getClock());

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
@@ -285,11 +285,14 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
 
   com.google.datastore.v1.RunQueryResponse runQuery(
       final com.google.datastore.v1.RunQueryRequest requestPb) {
-    com.google.cloud.datastore.telemetry.TraceUtil.Span span =
-        otelTraceUtil.startSpan(com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUN_QUERY);
     ReadOptions readOptions = requestPb.getReadOptions();
-    span.setAttribute(
-        "isTransactional", readOptions.hasTransaction() || readOptions.hasNewTransaction());
+    boolean isTransactional = readOptions.hasTransaction() || readOptions.hasNewTransaction();
+    String spanName =
+        (isTransactional
+            ? com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN_QUERY
+            : com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUN_QUERY);
+    com.google.cloud.datastore.telemetry.TraceUtil.Span span = otelTraceUtil.startSpan(spanName);
+    span.setAttribute("isTransactional", isTransactional);
     span.setAttribute("readConsistency", readOptions.getReadConsistency().toString());
 
     try (com.google.cloud.datastore.telemetry.TraceUtil.Scope ignored = span.makeCurrent()) {
@@ -302,7 +305,7 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
                   : TRANSACTION_OPERATION_EXCEPTION_HANDLER,
               getOptions().getClock());
       span.addEvent(
-          com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUN_QUERY + ": Completed",
+          spanName + ": Completed",
           new ImmutableMap.Builder<String, Object>()
               .put("Received", response.getBatch().getEntityResultsCount())
               .put("More results", response.getBatch().getMoreResults().toString())

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreImpl.java
@@ -143,10 +143,8 @@ final class DatastoreImpl extends BaseService<DatastoreOptions> implements Datas
     @Override
     public T call() throws DatastoreException {
       io.opentelemetry.api.trace.Span span =
-          Objects.requireNonNull(datastore
-                  .getOptions()
-                  .getOpenTelemetryOptions()
-                  .getOpenTelemetry())
+          Objects.requireNonNull(
+                  datastore.getOptions().getOpenTelemetryOptions().getOpenTelemetry())
               .getTracer(com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN)
               .spanBuilder(com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN)
               .setParent(

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/DisabledTraceUtil.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/DisabledTraceUtil.java
@@ -19,7 +19,9 @@ package com.google.cloud.datastore.telemetry;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
+import com.google.cloud.datastore.telemetry.TraceUtil.SpanContext;
 import io.grpc.ManagedChannelBuilder;
+import io.opentelemetry.api.trace.Span;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -30,6 +32,8 @@ import javax.annotation.Nullable;
  */
 @InternalApi
 public class DisabledTraceUtil implements TraceUtil {
+
+  static class SpanContext implements TraceUtil.SpanContext {}
 
   static class Span implements TraceUtil.Span {
     @Override
@@ -66,6 +70,10 @@ public class DisabledTraceUtil implements TraceUtil {
       return this;
     }
 
+    public io.opentelemetry.api.trace.Span getSpan() {
+      return null;
+    }
+
     @Override
     public Scope makeCurrent() {
       return new Scope();
@@ -96,7 +104,7 @@ public class DisabledTraceUtil implements TraceUtil {
   }
 
   @Override
-  public TraceUtil.Span startSpan(String spanName, TraceUtil.Context parent) {
+  public TraceUtil.Span startSpan(String spanName, TraceUtil.SpanContext parentSpanContext) {
     return new Span();
   }
 
@@ -110,5 +118,11 @@ public class DisabledTraceUtil implements TraceUtil {
   @Override
   public TraceUtil.Context getCurrentContext() {
     return new Context();
+  }
+
+  @Nonnull
+  @Override
+  public TraceUtil.SpanContext getCurrentSpanContext() {
+    return new SpanContext();
   }
 }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/DisabledTraceUtil.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/DisabledTraceUtil.java
@@ -22,6 +22,8 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.datastore.telemetry.TraceUtil.SpanContext;
 import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerProvider;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -33,7 +35,12 @@ import javax.annotation.Nullable;
 @InternalApi
 public class DisabledTraceUtil implements TraceUtil {
 
-  static class SpanContext implements TraceUtil.SpanContext {}
+  static class SpanContext implements TraceUtil.SpanContext {
+    @Override
+    public io.opentelemetry.api.trace.SpanContext getSpanContext() {
+      return null;
+    }
+  }
 
   static class Span implements TraceUtil.Span {
     @Override
@@ -124,5 +131,10 @@ public class DisabledTraceUtil implements TraceUtil {
   @Override
   public TraceUtil.SpanContext getCurrentSpanContext() {
     return new SpanContext();
+  }
+
+  @Override
+  public Tracer getTracer() {
+    return TracerProvider.noop().get(LIBRARY_NAME);
   }
 }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/EnabledTraceUtil.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/EnabledTraceUtil.java
@@ -80,7 +80,8 @@ public class EnabledTraceUtil implements TraceUtil {
       this.spanContext = spanContext;
     }
 
-    io.opentelemetry.api.trace.SpanContext getSpanContext() {
+    @Override
+    public io.opentelemetry.api.trace.SpanContext getSpanContext() {
       return this.spanContext;
     }
   }
@@ -306,7 +307,6 @@ public class EnabledTraceUtil implements TraceUtil {
 
   @Override
   public TraceUtil.Span startSpan(String spanName, TraceUtil.SpanContext parentSpanContext) {
-    assert (parentSpanContext instanceof SpanContext);
     SpanBuilder spanBuilder =
         tracer
             .spanBuilder(spanName)
@@ -314,8 +314,7 @@ public class EnabledTraceUtil implements TraceUtil {
             .setParent(
                 io.opentelemetry.context.Context.current()
                     .with(
-                        io.opentelemetry.api.trace.Span.wrap(
-                            ((SpanContext) parentSpanContext).getSpanContext())));
+                        io.opentelemetry.api.trace.Span.wrap(parentSpanContext.getSpanContext())));
     io.opentelemetry.api.trace.Span span =
         addSettingsAttributesToCurrentSpan(spanBuilder).startSpan();
     return new Span(span, spanName);
@@ -337,5 +336,10 @@ public class EnabledTraceUtil implements TraceUtil {
   @Override
   public TraceUtil.SpanContext getCurrentSpanContext() {
     return new SpanContext(io.opentelemetry.api.trace.Span.current().getSpanContext());
+  }
+
+  @Override
+  public Tracer getTracer() {
+    return this.tracer;
   }
 }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
@@ -22,6 +22,7 @@ import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.datastore.DatastoreOptions;
 import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -79,7 +80,9 @@ public interface TraceUtil {
   ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> getChannelConfigurator();
 
   /** Represents a trace span's context */
-  interface SpanContext {}
+  interface SpanContext {
+    io.opentelemetry.api.trace.SpanContext getSpanContext();
+  }
 
   /** Represents a trace span. */
   interface Span {
@@ -150,4 +153,7 @@ public interface TraceUtil {
   /** Returns the current SpanContext */
   @Nonnull
   SpanContext getCurrentSpanContext();
+
+  /** Returns the current OpenTelemetry Tracer when OpenTelemetry SDK is provided. */
+  Tracer getTracer();
 }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
@@ -42,6 +42,7 @@ public interface TraceUtil {
   static final String SPAN_NAME_BEGIN_TRANSACTION = "Transaction.Begin";
   static final String SPAN_NAME_TRANSACTION_LOOKUP = "Transaction.Lookup";
   static final String SPAN_NAME_TRANSACTION_COMMIT = "Transaction.Commit";
+  static final String SPAN_NAME_TRANSACTION_RUN_QUERY = "Transaction.RunQuery";
   static final String SPAN_NAME_ROLLBACK = "Transaction.Rollback";
   static final String SPAN_NAME_TRANSACTION_RUN_AGGREGATION_QUERY =
       "Transaction.RunAggregationQuery";

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
@@ -21,6 +21,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalExtensionOnly;
 import com.google.cloud.datastore.DatastoreOptions;
 import io.grpc.ManagedChannelBuilder;
+import io.opentelemetry.api.trace.Span;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -36,13 +37,15 @@ public interface TraceUtil {
   static final String SPAN_NAME_COMMIT = "Commit";
   static final String SPAN_NAME_RUN_QUERY = "RunQuery";
   static final String SPAN_NAME_RUN_AGGREGATION_QUERY = "RunAggregationQuery";
-  static final String SPAN_NAME_TRANSACTION_RUN = "Transaction.run";
+  static final String SPAN_NAME_TRANSACTION_RUN = "Transaction.Run";
   static final String SPAN_NAME_BEGIN_TRANSACTION = "Transaction.Begin";
   static final String SPAN_NAME_TRANSACTION_LOOKUP = "Transaction.Lookup";
   static final String SPAN_NAME_TRANSACTION_COMMIT = "Transaction.Commit";
   static final String SPAN_NAME_ROLLBACK = "Transaction.Rollback";
   static final String SPAN_NAME_TRANSACTION_RUN_AGGREGATION_QUERY =
       "Transaction.RunAggregationQuery";
+  static final String SPAN_NAME_ROLLBACK = "Transaction.Rollback";
+
   /**
    * Creates and returns an instance of the TraceUtil class.
    *
@@ -77,6 +80,9 @@ public interface TraceUtil {
   @Nullable
   ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> getChannelConfigurator();
 
+  /** Represents a trace span's context */
+  interface SpanContext {}
+
   /** Represents a trace span. */
   interface Span {
     /** Adds the given event to this span. */
@@ -93,6 +99,8 @@ public interface TraceUtil {
 
     /** Adds the given attribute to this span. */
     Span setAttribute(String key, boolean value);
+
+    io.opentelemetry.api.trace.Span getSpan();
 
     /** Marks this span as the current span. */
     Scope makeCurrent();
@@ -128,10 +136,10 @@ public interface TraceUtil {
   Span startSpan(String spanName);
 
   /**
-   * Starts a new span with the given name and the given context as its parent, sets it as the
-   * current span, and returns it.
+   * Starts a new span with the given name and the span represented by the parentSpanContext as its
+   * parents, sets it as the current span and returns it.
    */
-  Span startSpan(String spanName, Context parent);
+  Span startSpan(String spanName, SpanContext parentSpanContext);
 
   /** Returns the current span. */
   @Nonnull
@@ -140,4 +148,8 @@ public interface TraceUtil {
   /** Returns the current Context. */
   @Nonnull
   Context getCurrentContext();
+
+  /** Returns the current SpanContext */
+  @Nonnull
+  SpanContext getCurrentSpanContext();
 }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/telemetry/TraceUtil.java
@@ -44,8 +44,6 @@ public interface TraceUtil {
   static final String SPAN_NAME_ROLLBACK = "Transaction.Rollback";
   static final String SPAN_NAME_TRANSACTION_RUN_AGGREGATION_QUERY =
       "Transaction.RunAggregationQuery";
-  static final String SPAN_NAME_ROLLBACK = "Transaction.Rollback";
-
   /**
    * Creates and returns an instance of the TraceUtil class.
    *

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
@@ -26,6 +26,7 @@ import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUN_QUERY
 import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_COMMIT;
 import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_LOOKUP;
 import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN;
+import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN_QUERY;
 import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
 import static org.junit.Assert.assertEquals;
@@ -796,7 +797,48 @@ public class ITE2ETracingTest {
   }
 
   @Test
+  public void transactionQueryTest() throws Exception {
+    // Set up
+    Entity entity1 = Entity.newBuilder(KEY1).set("test_field", "test_value1").build();
+    Entity entity2 = Entity.newBuilder(KEY2).set("test_field", "test_value2").build();
+    List<Entity> entityList = new ArrayList<>();
+    entityList.add(entity1);
+    entityList.add(entity2);
+
+    List<Entity> response = datastore.add(entity1, entity2);
+    assertEquals(entityList, response);
+
+    assertNotNull(customSpanContext);
+
+    // Test
+    Span rootSpan = getNewRootSpanWithContext();
+    try (Scope ignored = rootSpan.makeCurrent()) {
+      Transaction transaction = datastore.newTransaction();
+      PropertyFilter filter = PropertyFilter.eq("test_field", entity1.getValue("test_field"));
+      Query<Entity> query =
+          Query.newEntityQueryBuilder().setKind(KEY1.getKind()).setFilter(filter).build();
+      QueryResults<Entity> queryResults = transaction.run(query);
+      transaction.commit();
+      assertTrue(queryResults.hasNext());
+      assertEquals(entity1, queryResults.next());
+      assertFalse(queryResults.hasNext());
+    } finally {
+      rootSpan.end();
+    }
+    waitForTracesToComplete();
+
+    fetchAndValidateTrace(
+        customSpanContext.getTraceId(),
+        /*numExpectedSpans=*/ 3,
+        Arrays.asList(
+            Collections.singletonList(SPAN_NAME_BEGIN_TRANSACTION),
+            Collections.singletonList(SPAN_NAME_TRANSACTION_RUN_QUERY),
+            Collections.singletonList(SPAN_NAME_TRANSACTION_COMMIT)));
+  }
+
+  @Test
   public void runInTransactionQueryTest() throws Exception {
+    // Set up
     Entity entity1 = Entity.newBuilder(KEY1).set("test_field", "test_value1").build();
     Entity entity2 = Entity.newBuilder(KEY2).set("test_field", "test_value2").build();
     List<Entity> entityList = new ArrayList<>();
@@ -837,7 +879,7 @@ public class ITE2ETracingTest {
   }
 
   @Test
-  public void runInTransactionAggregationQueryTest() throws Exception {}
+  public void transactionRunQueryTest() throws Exception {}
 
   @Test
   public void readWriteTransactionTraceTest() throws Exception {}

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
@@ -26,6 +26,7 @@ import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUN_QUERY
 import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_COMMIT;
 import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_LOOKUP;
 import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN;
+import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN_QUERY;
 import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
 import static org.junit.Assert.assertEquals;
@@ -831,10 +832,9 @@ public class ITE2ETracingTest {
         customSpanContext.getTraceId(),
         /*numExpectedSpans=*/ 4,
         Arrays.asList(
-            Collections.singletonList(SPAN_NAME_TRANSACTION_RUN),
-            Collections.singletonList(SPAN_NAME_BEGIN_TRANSACTION),
-            Collections.singletonList(SPAN_NAME_RUN_QUERY),
-            Collections.singletonList(SPAN_NAME_TRANSACTION_COMMIT)));
+            Arrays.asList(SPAN_NAME_TRANSACTION_RUN, SPAN_NAME_BEGIN_TRANSACTION),
+            Arrays.asList(SPAN_NAME_TRANSACTION_RUN, SPAN_NAME_RUN_QUERY),
+            Arrays.asList(SPAN_NAME_TRANSACTION_RUN, SPAN_NAME_TRANSACTION_COMMIT)));
   }
 
   @Test

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITE2ETracingTest.java
@@ -26,7 +26,6 @@ import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_RUN_QUERY
 import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_COMMIT;
 import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_LOOKUP;
 import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN;
-import static com.google.cloud.datastore.telemetry.TraceUtil.SPAN_NAME_TRANSACTION_RUN_QUERY;
 import static com.google.common.truth.Truth.assertThat;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
 import static org.junit.Assert.assertEquals;

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/telemetry/DisabledTraceUtilTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/telemetry/DisabledTraceUtilTest.java
@@ -38,7 +38,7 @@ public class DisabledTraceUtilTest {
     assertThat(traceUtil.getCurrentSpan() instanceof DisabledTraceUtil.Span).isTrue();
     assertThat(traceUtil.startSpan("foo") instanceof DisabledTraceUtil.Span).isTrue();
     assertThat(
-            traceUtil.startSpan("foo", traceUtil.getCurrentContext())
+            traceUtil.startSpan("foo", traceUtil.getCurrentSpanContext())
                 instanceof DisabledTraceUtil.Span)
         .isTrue();
   }

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/telemetry/EnabledTraceUtilTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/telemetry/EnabledTraceUtilTest.java
@@ -92,7 +92,7 @@ public class EnabledTraceUtilTest {
     assertThat(traceUtil.getCurrentSpan() instanceof EnabledTraceUtil.Span).isTrue();
     assertThat(traceUtil.startSpan("foo") != null).isTrue();
     assertThat(
-            traceUtil.startSpan("foo", traceUtil.getCurrentContext())
+            traceUtil.startSpan("foo", traceUtil.getCurrentSpanContext())
                 instanceof EnabledTraceUtil.Span)
         .isTrue();
   }


### PR DESCRIPTION
- This fixes the hierarchy of Spans appearing in a transaction under a Run method.
- Tested using existing transaction test

Fixes googleapis/google-cloud-java#11991  ☕️

