### PR TITLE
chore: fix hermetic_library_generation fork check

### DIFF
--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -20,11 +20,10 @@ on:
 env:
   HEAD_REF: ${{ github.head_ref }}
   REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+  GITHUB_REPOSITORY: ${{ github.repository }}
 
 jobs:
   library_generation:
-    # skip pull requests coming from a forked repository
-    if: github.env.REPO_FULL_NAME == github.repository
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -35,6 +34,10 @@ jobs:
       shell: bash
       run: |
         set -ex
+        if [[ "${GITHUB_REPOSITORY}" != "${REPO_FULL_NAME}" ]]; then
+          echo "This PR comes from a fork. Generation will be skipped"
+          exit 0
+        fi
         [ -z "$(git config user.email)" ] && git config --global user.email "cloud-java-bot@google.com"
         [ -z "$(git config user.name)" ] && git config --global user.name "cloud-java-bot"
         bash .github/scripts/hermetic_library_generation.sh \


### PR DESCRIPTION
This inlines the `repo.full_name` as an env var when checking if the PR is coming from a fork in order to prevent script injections.