### PR TITLE
fix(doc): Add discriptions for TransactionCallable interface

### DIFF
--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Datastore.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Datastore.java
@@ -57,7 +57,7 @@ public interface Datastore extends Service<DatastoreOptions>, DatastoreReaderWri
      * @param readerWriter DatastoreReaderWriter associated with the new transaction
      * @return T The transaction result
      * @throws Exception upon failure
-   */
+     */
     T run(DatastoreReaderWriter readerWriter) throws Exception;
   }
 

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Datastore.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/Datastore.java
@@ -51,6 +51,13 @@ public interface Datastore extends Service<DatastoreOptions>, DatastoreReaderWri
    * @param <T> the type of the return value
    */
   interface TransactionCallable<T> {
+    /**
+     * Callback's invoke method for the TransactionCallable.
+     *
+     * @param readerWriter DatastoreReaderWriter associated with the new transaction
+     * @return T The transaction result
+     * @throws Exception upon failure
+   */
     T run(DatastoreReaderWriter readerWriter) throws Exception;
   }
 


### PR DESCRIPTION
This is to fix empty descriptions for run method parameters, return result and exceptions for:

Link to Example: https://cloud.google.com/java/docs/reference/google-cloud-datastore/latest/com.google.cloud.datastore.Datastore.TransactionCallable?utc_end=1729273212.663