### PR TITLE
feat: Add firestoreInDatastoreMode for datastore emulator

### DIFF
--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -14,6 +14,11 @@ steps:
 - name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: pwd
 - name: gcr.io/cloud-devrel-public-resources/java8
+  entrypoint: echo
+  args: [
+    '${JAVA11_HOME}'
+  ]
+- name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: bash
   args: [
     '.kokoro/build.sh'
@@ -22,6 +27,7 @@ steps:
   - 'JOB_TYPE=samples'
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
   - 'KOKORO_GITHUB_PULL_REQUEST_NUMBER=$_PR_NUMBER'
+  - 'SUREFIRE_JVM_OPT=-Djvm=${JAVA11_HOME}/bin/java'
 - name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: echo
   args: [

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -22,8 +22,8 @@ steps:
   - 'JOB_TYPE=samples'
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
   - 'KOKORO_GITHUB_PULL_REQUEST_NUMBER=$_PR_NUMBER'
-  - 'JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
-  - 'JAVA=/usr/lib/jvm/java-11-openjdk-amd64'
+  - 'JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64'
+  - 'JAVA=/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
   - 'SUREFIRE_JVM_OPT=-Djvm=/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
 - name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: echo

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -22,9 +22,7 @@ steps:
   - 'JOB_TYPE=samples'
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
   - 'KOKORO_GITHUB_PULL_REQUEST_NUMBER=$_PR_NUMBER'
-  - 'JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64'
   - 'JAVA=/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
-  - 'SUREFIRE_JVM_OPT=-Djvm=/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
 - name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: echo
   args: [

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -24,7 +24,7 @@ steps:
   - 'KOKORO_GITHUB_PULL_REQUEST_NUMBER=$_PR_NUMBER'
   - 'JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64'
   - 'JAVA=/usr/lib/jvm/java-11-openjdk-amd64'
-  - 'SUREFIRE_JVM_OPT=-Djvm=$/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
+  - 'SUREFIRE_JVM_OPT=-Djvm=/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
 - name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: echo
   args: [

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -23,6 +23,8 @@ steps:
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
   - 'KOKORO_GITHUB_PULL_REQUEST_NUMBER=$_PR_NUMBER'
   - 'JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64'
+  - 'JAVA=/usr/lib/jvm/java-11-openjdk-amd64'
+  - 'SUREFIRE_JVM_OPT=-Djvm=$/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
 - name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: echo
   args: [

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -1,19 +1,19 @@
 steps:
-- name: gcr.io/cloud-devrel-public-resources/java8
+- name: gcr.io/cloud-devrel-public-resources/java11
   entrypoint: ls
   args: [
     '-alt',
   ]
-- name: gcr.io/cloud-devrel-public-resources/java8
+- name: gcr.io/cloud-devrel-public-resources/java11
   entrypoint: curl
   args: [
     '--header',
     'Metadata-Flavor: Google',
     'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email'
   ]
-- name: gcr.io/cloud-devrel-public-resources/java8
+- name: gcr.io/cloud-devrel-public-resources/java11
   entrypoint: pwd
-- name: gcr.io/cloud-devrel-public-resources/java8
+- name: gcr.io/cloud-devrel-public-resources/java11
   entrypoint: bash
   args: [
     '.kokoro/build.sh'
@@ -22,8 +22,7 @@ steps:
   - 'JOB_TYPE=samples'
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
   - 'KOKORO_GITHUB_PULL_REQUEST_NUMBER=$_PR_NUMBER'
-  - 'JAVA=/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
-- name: gcr.io/cloud-devrel-public-resources/java8
+- name: gcr.io/cloud-devrel-public-resources/java11
   entrypoint: echo
   args: [
     'Sample job succeeded',

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -14,11 +14,6 @@ steps:
 - name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: pwd
 - name: gcr.io/cloud-devrel-public-resources/java8
-  entrypoint: echo
-  args: [
-    '${JAVA11_HOME}'
-  ]
-- name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: bash
   args: [
     '.kokoro/build.sh'
@@ -27,7 +22,7 @@ steps:
   - 'JOB_TYPE=samples'
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
   - 'KOKORO_GITHUB_PULL_REQUEST_NUMBER=$_PR_NUMBER'
-  - 'SUREFIRE_JVM_OPT=-Djvm=${JAVA11_HOME}/bin/java'
+  - 'SUREFIRE_JVM_OPT=-Djvm=/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
 - name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: echo
   args: [

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -22,7 +22,7 @@ steps:
   - 'JOB_TYPE=samples'
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
   - 'KOKORO_GITHUB_PULL_REQUEST_NUMBER=$_PR_NUMBER'
-  - 'JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64'
+  - 'JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
   - 'JAVA=/usr/lib/jvm/java-11-openjdk-amd64'
   - 'SUREFIRE_JVM_OPT=-Djvm=/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
 - name: gcr.io/cloud-devrel-public-resources/java8

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -22,7 +22,7 @@ steps:
   - 'JOB_TYPE=samples'
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
   - 'KOKORO_GITHUB_PULL_REQUEST_NUMBER=$_PR_NUMBER'
-  - 'SUREFIRE_JVM_OPT=-Djvm=/usr/lib/jvm/java-11-openjdk-amd64/bin/java'
+  - 'JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64'
 - name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: echo
   args: [

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
         env:
           JOB_TYPE: test
   windows:
-    # Building using Java 8 and run the tests with Java 11 runtime
+    # Building using Java 11 and run the tests with Java 8 runtime
     runs-on: windows-latest
     steps:
     - name: Support longpaths
@@ -69,12 +69,6 @@ jobs:
       with:
         java-version: 8
         distribution: temurin
-#    - name: "Set Java system property environment variable for surefire plugin (unit tests)"
-#      # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
-#      # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
-##      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
-#      run: echo "JAVA=${JAVA_HOME}\bin\java" >> $GITHUB_ENV
-#      shell: bash
     - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
       run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}\bin\java" >> $GITHUB_ENV
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,8 @@ jobs:
     - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
       # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
       # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
-      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
+#      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
+      run: echo "JAVA=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
       shell: bash
     - uses: actions/setup-java@v4
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
       run: echo "JAVA=${JAVA_HOME}\bin\java" >> $GITHUB_ENV
       shell: bash
     - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
-      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
+      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}\bin\java" >> $GITHUB_ENV
       shell: bash
     - uses: actions/setup-java@v4
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,21 +67,21 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
-        java-version: 11
+        java-version: 8
         distribution: temurin
-    - name: "Set Java system property environment variable for surefire plugin (unit tests)"
-      # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
-      # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
-#      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
-      run: echo "JAVA=${JAVA_HOME}\bin\java" >> $GITHUB_ENV
-      shell: bash
+#    - name: "Set Java system property environment variable for surefire plugin (unit tests)"
+#      # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
+#      # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
+##      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
+#      run: echo "JAVA=${JAVA_HOME}\bin\java" >> $GITHUB_ENV
+#      shell: bash
     - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
       run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}\bin\java" >> $GITHUB_ENV
       shell: bash
-#    - uses: actions/setup-java@v4
-#      with:
-#        distribution: temurin
-#        java-version: 8
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 11
     - run: java -version
     - run: .kokoro/build.bat
       env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,10 +78,10 @@ jobs:
     - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
       run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}\bin\java" >> $GITHUB_ENV
       shell: bash
-    - uses: actions/setup-java@v4
-      with:
-        distribution: temurin
-        java-version: 8
+#    - uses: actions/setup-java@v4
+#      with:
+#        distribution: temurin
+#        java-version: 8
     - run: java -version
     - run: .kokoro/build.bat
       env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,11 +59,21 @@ jobs:
         env:
           JOB_TYPE: test
   windows:
+    # Building using Java 8 and run the tests with Java 11 runtime
     runs-on: windows-latest
     steps:
     - name: Support longpaths
       run: git config --system core.longpaths true
     - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        java-version: 11
+        distribution: temurin
+    - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
+      # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
+      # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
+      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
+      shell: bash
     - uses: actions/setup-java@v4
       with:
         distribution: temurin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
       # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
       # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
 #      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
-      run: echo "JAVA=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
+      run: echo "JAVA=${JAVA_HOME}\bin\java" >> $GITHUB_ENV
       shell: bash
     - uses: actions/setup-java@v4
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,11 +69,14 @@ jobs:
       with:
         java-version: 11
         distribution: temurin
-    - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
+    - name: "Set Java system property environment variable for surefire plugin (unit tests)"
       # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
       # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
 #      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
       run: echo "JAVA=${JAVA_HOME}\bin\java" >> $GITHUB_ENV
+      shell: bash
+    - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
+      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
       shell: bash
     - uses: actions/setup-java@v4
       with:

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -60,16 +60,16 @@ javadoc)
     RETURN_CODE=$?
     ;;
 integration)
-    # Kokoro integration test uses both JDK 11 and JDK 8. Integration
-    # tests require JDK 11 to compile the classes.
+    # Kokoro integration tests use both JDK 11 and JDK 8. Integration
+    # tests require JDK 11 export as JAVA env variable to run cloud datastore
+    # emulator (https://cloud.google.com/sdk/docs/release-notes#39300_2022-07-12).
+    # For Java 8 environment, we will still run the tests using Java 8 with
+    # SUREFIRE_JVM_OPT for Maven surefire plugin:
+    # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
     if [[ -n "${JAVA11_HOME}"  &&  -n "${JAVA8_HOME}" ]]
     then
       export JAVA=${JAVA11_HOME}/bin/java
       export SUREFIRE_JVM_OPT=-Djvm=${JAVA8_HOME}/bin/java
-      echo "Java:${JAVA}"
-      echo "Java 11:${JAVA11_HOME}"
-      echo "Java 8:${JAVA8_HOME}"
-      echo "SUREFIRE_JVM_OPT: ${SUREFIRE_JVM_OPT}"
     fi
 
     mvn -B ${INTEGRATION_TEST_ARGS} \

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -27,6 +27,7 @@ source ${scriptDir}/common.sh
 # require JDK 11 to compile the classes touching GraalVM classes.
 if [ -n "${JAVA11_HOME}" ]; then
   setJava "${JAVA11_HOME}"
+  echo "Java: ${JAVA}"
 fi
 
 

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -104,6 +104,7 @@ samples)
           -Dclirr.skip=true \
           -Denforcer.skip=true \
           -fae \
+          ${SUREFIRE_JVM_OPT} \
           verify
         RETURN_CODE=$?
         popd

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -82,6 +82,8 @@ graalvm17)
     ;;
 samples)
     SAMPLES_DIR=samples
+    echo "SUREFIRE_JVM_OPT: ${SUREFIRE_JVM_OPT}"
+    echo "Java 11: ${JAVA11_HOME}"
     # only run ITs in snapshot/ on presubmit PRs. run ITs in all 3 samples/ subdirectories otherwise.
     if [[ ! -z ${KOKORO_GITHUB_PULL_REQUEST_NUMBER} ]]
     then

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -62,7 +62,7 @@ javadoc)
 integration)
     # Kokoro integration test uses both JDK 11 and JDK 8. Integration
     # tests require JDK 11 to compile the classes.
-    if [ -n "${JAVA11_HOME}" ] && [ -n "${JAVA8_HOME}" ]; then
+    if [[ -n "${JAVA11_HOME}"  &&  -n "${JAVA8_HOME}" ]]; then
       export JAVA=${JAVA11_HOME}/bin/java
       export SUREFIRE_JVM_OPT="-Djvm=${JAVA8_HOME}/bin/java"
       echo "Java:${JAVA}"

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -78,6 +78,7 @@ integration)
       -Dclirr.skip=true \
       -Denforcer.skip=true \
       -fae \
+      ${SUREFIRE_JVM_OPT} \
       verify
     RETURN_CODE=$?
     ;;

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -69,6 +69,15 @@ javadoc)
     RETURN_CODE=$?
     ;;
 integration)
+    if [ -n "${JAVA11_HOME}" ] && [ -n "${JAVA8_HOME}" ]; then
+      export JAVA=${JAVA11_HOME}/bin/java
+      export SUREFIRE_JVM_OPT="-Djvm=${JAVA8_HOME}/bin/java"
+      echo "Java:${JAVA}"
+      echo "Java 11:${JAVA11_HOME}"
+      echo "Java 8:${JAVA8_HOME}"
+      echo "SUREFIRE_JVM_OPT: ${SUREFIRE_JVM_OPT}"
+    fi
+    ;;
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \
       -Penable-integration-tests \

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -62,15 +62,16 @@ javadoc)
 integration)
     # Kokoro integration test uses both JDK 11 and JDK 8. Integration
     # tests require JDK 11 to compile the classes.
-    if [[ -n "${JAVA11_HOME}"  &&  -n "${JAVA8_HOME}" ]]; then
+    if [[ -n "${JAVA11_HOME}"  &&  -n "${JAVA8_HOME}" ]]
+    then
       export JAVA=${JAVA11_HOME}/bin/java
-      export SUREFIRE_JVM_OPT="-Djvm=${JAVA8_HOME}/bin/java"
+      export SUREFIRE_JVM_OPT=-Djvm=${JAVA8_HOME}/bin/java
       echo "Java:${JAVA}"
       echo "Java 11:${JAVA11_HOME}"
       echo "Java 8:${JAVA8_HOME}"
       echo "SUREFIRE_JVM_OPT: ${SUREFIRE_JVM_OPT}"
     fi
-    ;;
+
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \
       -Penable-integration-tests \

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -70,7 +70,10 @@ javadoc)
 integration)
   echo "SUREFIRE_JVM_OPT: ${SUREFIRE_JVM_OPT}"
   echo "Java 11: ${JAVA11_HOME}"
+  echo "JAVA_HOME: ${JAVA_HOME}"
   echo "Java: ${JAVA}"
+  echo "INTEGRATION_TEST_ARGS: ${INTEGRATION_TEST_ARGS}"
+  java -version
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \
       -Penable-integration-tests \

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -25,7 +25,7 @@ source ${scriptDir}/common.sh
 
 # Kokoro integration test uses both JDK 11 and JDK 8. Integration
 # tests require JDK 11 to compile the classes.
-if [ -n "${JAVA11_HOME}" && ! -z "${JAVA8_HOME}"]; then
+if [ -n "${JAVA11_HOME}" && ! -n "${JAVA8_HOME}"]; then
   setJava "${JAVA11_HOME}"
   echo "Java:${JAVA}"
   echo "Java 11:${JAVA11_HOME}"

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -23,15 +23,6 @@ cd ${scriptDir}/..
 # include common functions
 source ${scriptDir}/common.sh
 
-# Kokoro integration test uses both JDK 11 and JDK 8. Integration
-# tests require JDK 11 to compile the classes.
-if [ -n "${JAVA11_HOME}" && ! -n "${JAVA8_HOME}"]; then
-  setJava "${JAVA11_HOME}"
-  echo "Java:${JAVA}"
-  echo "Java 11:${JAVA11_HOME}"
-  echo "Java 8:${JAVA8_HOME}"
-fi
-
 # Print out Maven & Java version
 mvn -version
 echo ${JOB_TYPE}
@@ -69,6 +60,8 @@ javadoc)
     RETURN_CODE=$?
     ;;
 integration)
+    # Kokoro integration test uses both JDK 11 and JDK 8. Integration
+    # tests require JDK 11 to compile the classes.
     if [ -n "${JAVA11_HOME}" ] && [ -n "${JAVA8_HOME}" ]; then
       export JAVA=${JAVA11_HOME}/bin/java
       export SUREFIRE_JVM_OPT="-Djvm=${JAVA8_HOME}/bin/java"

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -27,6 +27,9 @@ source ${scriptDir}/common.sh
 # tests require JDK 11 to compile the classes.
 if [ -n "${JAVA11_HOME}" && ! -z "${JAVA8_HOME}"]; then
   setJava "${JAVA11_HOME}"
+  echo "Java:${JAVA}"
+  echo "Java 11:${JAVA11_HOME}"
+  echo "Java 8:${JAVA8_HOME}"
 fi
 
 # Print out Maven & Java version
@@ -66,7 +69,6 @@ javadoc)
     RETURN_CODE=$?
     ;;
 integration)
-  java -version
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \
       -Penable-integration-tests \

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -60,6 +60,9 @@ javadoc)
     RETURN_CODE=$?
     ;;
 integration)
+  echo "SUREFIRE_JVM_OPT: ${SUREFIRE_JVM_OPT}"
+  echo "Java 11: ${JAVA11_HOME}"
+  echo "Java: ${JAVA}"
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \
       -Penable-integration-tests \

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -23,13 +23,11 @@ cd ${scriptDir}/..
 # include common functions
 source ${scriptDir}/common.sh
 
-# Kokoro integration test uses both JDK 11 and JDK 8. GraalVM dependencies
-# require JDK 11 to compile the classes touching GraalVM classes.
-if [ -n "${JAVA11_HOME}" ]; then
+# Kokoro integration test uses both JDK 11 and JDK 8. Integration
+# tests require JDK 11 to compile the classes.
+if [ -n "${JAVA11_HOME}" && ! -z "${JAVA8_HOME}"]; then
   setJava "${JAVA11_HOME}"
-  echo "Java: ${JAVA}"
 fi
-
 
 # Print out Maven & Java version
 mvn -version
@@ -68,11 +66,6 @@ javadoc)
     RETURN_CODE=$?
     ;;
 integration)
-  echo "SUREFIRE_JVM_OPT: ${SUREFIRE_JVM_OPT}"
-  echo "Java 11: ${JAVA11_HOME}"
-  echo "JAVA_HOME: ${JAVA_HOME}"
-  echo "Java: ${JAVA}"
-  echo "INTEGRATION_TEST_ARGS: ${INTEGRATION_TEST_ARGS}"
   java -version
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \
@@ -81,7 +74,6 @@ integration)
       -Dclirr.skip=true \
       -Denforcer.skip=true \
       -fae \
-      ${SUREFIRE_JVM_OPT} \
       verify
     RETURN_CODE=$?
     ;;
@@ -97,8 +89,6 @@ graalvm17)
     ;;
 samples)
     SAMPLES_DIR=samples
-    echo "SUREFIRE_JVM_OPT: ${SUREFIRE_JVM_OPT}"
-    echo "Java 11: ${JAVA11_HOME}"
     # only run ITs in snapshot/ on presubmit PRs. run ITs in all 3 samples/ subdirectories otherwise.
     if [[ ! -z ${KOKORO_GITHUB_PULL_REQUEST_NUMBER} ]]
     then
@@ -119,7 +109,6 @@ samples)
           -Dclirr.skip=true \
           -Denforcer.skip=true \
           -fae \
-          ${SUREFIRE_JVM_OPT} \
           verify
         RETURN_CODE=$?
         popd

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -23,6 +23,13 @@ cd ${scriptDir}/..
 # include common functions
 source ${scriptDir}/common.sh
 
+# Kokoro integration test uses both JDK 11 and JDK 8. GraalVM dependencies
+# require JDK 11 to compile the classes touching GraalVM classes.
+if [ -n "${JAVA11_HOME}" ]; then
+  setJava "${JAVA11_HOME}"
+fi
+
+
 # Print out Maven & Java version
 mvn -version
 echo ${JOB_TYPE}

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -58,6 +58,8 @@ function msg() { println "$*" >&2; }
 function println() { printf '%s\n' "$(now) $*"; }
 function setJava() {
   export JAVA=$1/bin/java
+  export JAVA_HOME=$1
+  export PATH=${JAVA_HOME}/bin:$PATH
 }
 
 ## Helper comment to trigger updated repo dependency release

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -52,9 +52,12 @@ function retry_with_backoff {
     return $exit_code
 }
 
-## Helper functionss
+## Helper functions
 function now() { date +"%Y-%m-%d %H:%M:%S" | tr -d '\n'; }
 function msg() { println "$*" >&2; }
 function println() { printf '%s\n' "$(now) $*"; }
+function setJava() {
+  export JAVA=$1/bin/java
+}
 
 ## Helper comment to trigger updated repo dependency release

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -58,9 +58,6 @@ function msg() { println "$*" >&2; }
 function println() { printf '%s\n' "$(now) $*"; }
 function setJava() {
   export JAVA=$1/bin/java
-  export JAVA_HOME=$1
-  export SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java
-  export PATH=${JAVA_HOME}/bin:$PATH
 }
 
 ## Helper comment to trigger updated repo dependency release

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -56,8 +56,5 @@ function retry_with_backoff {
 function now() { date +"%Y-%m-%d %H:%M:%S" | tr -d '\n'; }
 function msg() { println "$*" >&2; }
 function println() { printf '%s\n' "$(now) $*"; }
-function setJava() {
-  export JAVA=$1/bin/java
-}
 
 ## Helper comment to trigger updated repo dependency release

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -59,6 +59,7 @@ function println() { printf '%s\n' "$(now) $*"; }
 function setJava() {
   export JAVA=$1/bin/java
   export JAVA_HOME=$1
+  export SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java
   export PATH=${JAVA_HOME}/bin:$PATH
 }
 

--- a/.kokoro/presubmit/integration.cfg
+++ b/.kokoro/presubmit/integration.cfg
@@ -36,8 +36,3 @@ env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "java-it-service-account"
 }
-
-env_vars: {
-  key: "JAVA"
-  value: "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
-}

--- a/.kokoro/presubmit/integration.cfg
+++ b/.kokoro/presubmit/integration.cfg
@@ -36,3 +36,8 @@ env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "java-it-service-account"
 }
+
+env_vars: {
+  key: "JAVA_HOME"
+  value: "/usr/lib/jvm/java-11-openjdk-amd64"
+}

--- a/.kokoro/presubmit/integration.cfg
+++ b/.kokoro/presubmit/integration.cfg
@@ -38,6 +38,6 @@ env_vars: {
 }
 
 env_vars: {
-  key: "JAVA_HOME"
-  value: "/usr/lib/jvm/java-11-openjdk-amd64"
+  key: "JAVA"
+  value: "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
 }

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-datastore</artifactId>
-  <version>2.25.1</version>
+  <version>2.25.2</version>
 </dependency>
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>26.52.0</version>
+      <version>26.53.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -190,7 +190,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
     List<String> binCommand = new ArrayList<>(Arrays.asList(binName, "start"));
     binCommand.add("--testing");
     if (builder.firestoreInDatastoreMode) {
-      binCommand.add(FIRESTORE_IN_DATASTORE_MODE_FLAG);
+      binCommand.add("--firestore_in_datastore_mode");
     } else {
       // At most one of --consistency | --use-firestore-in-datastore-mode can be specified.
       // --consistency will be ignored with --use-firestore-in-datastore-mode.

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -81,7 +81,6 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
       "--use-firestore-in-datastore-mode";
 
   private static final Logger LOGGER = Logger.getLogger(LocalDatastoreHelper.class.getName());
-  LOGGER.
 
   static {
     try {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -188,6 +188,8 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
     List<String> binCommand = new ArrayList<>(Arrays.asList(binName, "start"));
     binCommand.add("--testing");
     if (builder.firestoreInDatastoreMode) {
+      // Downloadable emulator runner takes the flag in a different
+      // format: --firestore_in_datastore_mode
       binCommand.add("--firestore_in_datastore_mode");
     } else {
       // At most one of --consistency | --firestore_in_datastore_mode can be specified.

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -26,7 +26,9 @@ import com.google.cloud.ServiceOptions;
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.testing.BaseEmulatorHelper;
 import com.google.common.collect.ImmutableList;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.FileVisitResult;
@@ -79,6 +81,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
       "--use-firestore-in-datastore-mode";
 
   private static final Logger LOGGER = Logger.getLogger(LocalDatastoreHelper.class.getName());
+  LOGGER.
 
   static {
     try {
@@ -323,6 +326,34 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
    */
   @Override
   public void start() throws IOException, InterruptedException {
+    try {
+      // Run the gcloud --version command
+      Process process = Runtime.getRuntime().exec("gcloud --version");
+      BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+      String line;
+      StringBuilder output = new StringBuilder();
+      while ((line = reader.readLine()) != null) {
+        output.append(line).append("\n");
+      }
+
+      // Check the exit code to see if the command was successful
+      int exitCode = process.waitFor();
+      if (exitCode == 0) {
+        System.out.println("gcloud is installed.\nVersion information:\n" + output);
+        LOGGER.info("gcloud is installed.\nVersion information:\n" + output);
+      } else {
+        System.err.println("gcloud is not installed or not in the PATH.");
+        LOGGER.severe("gcloud is not installed or not in the PATH.");
+      }
+
+    } catch (IOException | InterruptedException e) {
+      System.err.println("Error checking gcloud installation: " + e.getMessage());
+      LOGGER.severe("Error checking gcloud installation: " + e.getMessage());
+    }
+
+    String Java_version = System.getenv("JAVA");
+    LOGGER.info("java_evn Java: " + Java_version);
     String blockUntilOutput = "Dev App Server is now running";
     startProcess(blockUntilOutput);
   }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -26,9 +26,7 @@ import com.google.cloud.ServiceOptions;
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.testing.BaseEmulatorHelper;
 import com.google.common.collect.ImmutableList;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.FileVisitResult;
@@ -192,8 +190,8 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
     if (builder.firestoreInDatastoreMode) {
       binCommand.add("--firestore_in_datastore_mode");
     } else {
-      // At most one of --consistency | --use-firestore-in-datastore-mode can be specified.
-      // --consistency will be ignored with --use-firestore-in-datastore-mode.
+      // At most one of --consistency | --firestore_in_datastore_mode can be specified.
+      // --consistency will be ignored with --firestore_in_datastore_mode.
       binCommand.add(CONSISTENCY_FLAG + getConsistency());
     }
     binCommand.add(BIN_CMD_PORT_FLAG + getPort());
@@ -325,34 +323,6 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
    */
   @Override
   public void start() throws IOException, InterruptedException {
-    try {
-      // Run the gcloud --version command
-      Process process = Runtime.getRuntime().exec("gcloud --version");
-      BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-
-      String line;
-      StringBuilder output = new StringBuilder();
-      while ((line = reader.readLine()) != null) {
-        output.append(line).append("\n");
-      }
-
-      // Check the exit code to see if the command was successful
-      int exitCode = process.waitFor();
-      if (exitCode == 0) {
-        System.out.println("gcloud is installed.\nVersion information:\n" + output);
-        LOGGER.info("gcloud is installed.\nVersion information:\n" + output);
-      } else {
-        System.err.println("gcloud is not installed or not in the PATH.");
-        LOGGER.severe("gcloud is not installed or not in the PATH.");
-      }
-
-    } catch (IOException | InterruptedException e) {
-      System.err.println("Error checking gcloud installation: " + e.getMessage());
-      LOGGER.severe("Error checking gcloud installation: " + e.getMessage());
-    }
-
-    String Java_version = System.getenv("JAVA");
-    LOGGER.info("java_evn Java: " + Java_version);
     String blockUntilOutput = "Dev App Server is now running";
     startProcess(blockUntilOutput);
   }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -59,7 +59,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
   private static final String GCLOUD_CMD_TEXT = "gcloud beta emulators datastore start";
   private static final String GCLOUD_CMD_PORT_FLAG = "--host-port=";
   private static final String VERSION_PREFIX = "cloud-datastore-emulator ";
-  private static final String MIN_VERSION = "2.2.2";
+  private static final String MIN_VERSION = "2.3.0";
 
   // Downloadable emulator settings
   private static final String BIN_NAME = "cloud-datastore-emulator/cloud_datastore_emulator";

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -59,7 +59,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
   private static final String GCLOUD_CMD_TEXT = "gcloud beta emulators datastore start";
   private static final String GCLOUD_CMD_PORT_FLAG = "--host-port=";
   private static final String VERSION_PREFIX = "cloud-datastore-emulator ";
-  private static final String MIN_VERSION = "2.0.2";
+  private static final String MIN_VERSION = "2.3.1";
 
   // Downloadable emulator settings
   private static final String BIN_NAME = "cloud-datastore-emulator/cloud_datastore_emulator";

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -76,7 +76,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
   private static final double DEFAULT_CONSISTENCY = 0.9;
   private static final String DEFAULT_PROJECT_ID = PROJECT_ID_PREFIX + UUID.randomUUID();
   private static final String FIRESTORE_IN_DATASTORE_MODE_FLAG =
-          "--use-firestore-in-datastore-mode";
+      "--use-firestore-in-datastore-mode";
 
   private static final Logger LOGGER = Logger.getLogger(LocalDatastoreHelper.class.getName());
 
@@ -141,6 +141,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
       this.storeOnDisk = storeOnDisk;
       return this;
     }
+
     public Builder setFirestoreInDatastoreMode(boolean firestoreInDatastoreMode) {
       this.firestoreInDatastoreMode = firestoreInDatastoreMode;
       return this;
@@ -187,7 +188,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
     List<String> binCommand = new ArrayList<>(Arrays.asList(binName, "start"));
     binCommand.add("--testing");
     if (builder.firestoreInDatastoreMode) {
-       binCommand.add(FIRESTORE_IN_DATASTORE_MODE_FLAG);
+      binCommand.add(FIRESTORE_IN_DATASTORE_MODE_FLAG);
     } else {
       // At most one of --consistency | --use-firestore-in-datastore-mode can be specified.
       // --consistency will be ignored with --use-firestore-in-datastore-mode.
@@ -257,7 +258,9 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
     return storeOnDisk;
   }
 
-  /** Returns {@code true} use firestore-in-datastore-mode, otherwise {@code false} use native mode. */
+  /**
+   * Returns {@code true} use firestore-in-datastore-mode, otherwise {@code false} use native mode.
+   */
   public boolean isFirestoreInDatastoreMode() {
     return firestoreInDatastoreMode;
   }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -59,7 +59,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
   private static final String GCLOUD_CMD_TEXT = "gcloud beta emulators datastore start";
   private static final String GCLOUD_CMD_PORT_FLAG = "--host-port=";
   private static final String VERSION_PREFIX = "cloud-datastore-emulator ";
-  private static final String MIN_VERSION = "2.3.1";
+  private static final String MIN_VERSION = "2.2.2";
 
   // Downloadable emulator settings
   private static final String BIN_NAME = "cloud-datastore-emulator/cloud_datastore_emulator";

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -59,7 +59,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
   private static final String GCLOUD_CMD_TEXT = "gcloud beta emulators datastore start";
   private static final String GCLOUD_CMD_PORT_FLAG = "--host-port=";
   private static final String VERSION_PREFIX = "cloud-datastore-emulator ";
-  private static final String MIN_VERSION = "2.3.0";
+  private static final String MIN_VERSION = "2.2.1";
 
   // Downloadable emulator settings
   private static final String BIN_NAME = "cloud-datastore-emulator/cloud_datastore_emulator";

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java
@@ -59,7 +59,7 @@ public class LocalDatastoreHelper extends BaseEmulatorHelper<DatastoreOptions> {
   private static final String GCLOUD_CMD_TEXT = "gcloud beta emulators datastore start";
   private static final String GCLOUD_CMD_PORT_FLAG = "--host-port=";
   private static final String VERSION_PREFIX = "cloud-datastore-emulator ";
-  private static final String MIN_VERSION = "2.2.1";
+  private static final String MIN_VERSION = "2.3.1";
 
   // Downloadable emulator settings
   private static final String BIN_NAME = "cloud-datastore-emulator/cloud_datastore_emulator";

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/ITLocalDatastoreHelperTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/ITLocalDatastoreHelperTest.java
@@ -211,10 +211,12 @@ public class ITLocalDatastoreHelperTest {
       assertNotNull(ex.getMessage());
     }
   }
-    @Test
+
+  @Test
   public void testCreateWithFirestoreInDatastoreMode()
-          throws IOException, InterruptedException, TimeoutException {
-    LocalDatastoreHelper helper = LocalDatastoreHelper.newBuilder().setFirestoreInDatastoreMode(true).build();
+      throws IOException, InterruptedException, TimeoutException {
+    LocalDatastoreHelper helper =
+        LocalDatastoreHelper.newBuilder().setFirestoreInDatastoreMode(true).build();
     assertTrue(helper.isFirestoreInDatastoreMode());
     helper.start();
     Datastore datastore = helper.getOptions().getService();

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/ITLocalDatastoreHelperTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/ITLocalDatastoreHelperTest.java
@@ -76,11 +76,13 @@ public class ITLocalDatastoreHelperTest {
             .setConsistency(0.75)
             .setPort(8081)
             .setStoreOnDisk(false)
+            .setFirestoreInDatastoreMode(true)
             .setDataDir(dataDir)
             .build();
     assertTrue(Math.abs(0.75 - helper.getConsistency()) < TOLERANCE);
     assertTrue(helper.getProjectId().startsWith(PROJECT_ID_PREFIX));
     assertFalse(helper.isStoreOnDisk());
+    assertTrue(helper.isFirestoreInDatastoreMode());
     assertEquals(8081, helper.getPort());
     assertEquals(dataDir, helper.getGcdPath());
     LocalDatastoreHelper incompleteHelper = LocalDatastoreHelper.newBuilder().build();
@@ -103,11 +105,13 @@ public class ITLocalDatastoreHelperTest {
             .setConsistency(0.75)
             .setPort(8081)
             .setStoreOnDisk(false)
+            .setFirestoreInDatastoreMode(true)
             .setDataDir(dataDir)
             .build();
     assertTrue(Math.abs(0.75 - helper.getConsistency()) < TOLERANCE);
     assertTrue(helper.getProjectId().startsWith(PROJECT_ID_PREFIX));
     assertFalse(helper.isStoreOnDisk());
+    assertTrue(helper.isFirestoreInDatastoreMode());
     assertEquals(8081, helper.getPort());
     assertEquals(dataDir, helper.getGcdPath());
     LocalDatastoreHelper actualHelper = helper.toBuilder().build();
@@ -119,10 +123,12 @@ public class ITLocalDatastoreHelperTest {
             .setConsistency(0.85)
             .setPort(9091)
             .setStoreOnDisk(true)
+            .setFirestoreInDatastoreMode(false)
             .setDataDir(dataDir)
             .build();
     assertTrue(Math.abs(0.85 - actualHelper.getConsistency()) < TOLERANCE);
     assertTrue(actualHelper.isStoreOnDisk());
+    assertFalse(actualHelper.isFirestoreInDatastoreMode());
     assertEquals(9091, actualHelper.getPort());
     assertEquals(dataDir, actualHelper.getGcdPath());
     LocalDatastoreHelper.deleteRecursively(dataDir);
@@ -205,11 +211,27 @@ public class ITLocalDatastoreHelperTest {
       assertNotNull(ex.getMessage());
     }
   }
+    @Test
+  public void testCreateWithFirestoreInDatastoreMode()
+          throws IOException, InterruptedException, TimeoutException {
+    LocalDatastoreHelper helper = LocalDatastoreHelper.newBuilder().setFirestoreInDatastoreMode(true).build();
+    assertTrue(helper.isFirestoreInDatastoreMode());
+    helper.start();
+    Datastore datastore = helper.getOptions().getService();
+    Key key = datastore.newKeyFactory().setKind("kind").newKey("name");
+    Entity expected = Entity.newBuilder(key).build();
+    datastore.put(expected);
+    assertNotNull(datastore.get(key));
+    Entity actual = datastore.get(key);
+    assertEquals(expected, actual);
+    helper.stop();
+  }
 
   public void assertLocalDatastoreHelpersEquivelent(
       LocalDatastoreHelper expected, LocalDatastoreHelper actual) {
     assertEquals(expected.getConsistency(), actual.getConsistency(), 0);
     assertEquals(expected.isStoreOnDisk(), actual.isStoreOnDisk());
+    assertEquals(expected.isFirestoreInDatastoreMode(), actual.isFirestoreInDatastoreMode());
     assertEquals(expected.getGcdPath(), actual.getGcdPath());
   }
 }


### PR DESCRIPTION
**Background**
The newer cloud datastore emulator 2.3.1 supports Firestore in Datastore mode, using the argument --use-firestore-in-datastore-mode: https://cloud.google.com/sdk/gcloud/reference/beta/emulators/datastore/start. We want to introduce the same feature to java-datastore client. More details:
https://cloud.google.com/datastore/docs/tools/datastore-emulator#known_issues

**Changes**
This PR is to introduce "--use-firestore-in-datastore-mode" so datastore client can support datastore emulator with fireStoreInDatastoreMode. The changes is made to LocalDatastoreHelper, which is the class in Java datastore client to manage data emulator life cycle. 

**Challenges**
One issue I ran into is that cloud datastore emulator 2.3.1 which includes `--use-firestore-in-datastore-mode` feature doesn't support Java8. According to Patrick, this was an intentional flip due to Google build environment: https://cloud.google.com/sdk/docs/release-notes#39300_2022-07-12

**Testing changes**
This PR also includes some changes to solve the above issue on Java8 testing VMs.
Currently cloud datastore emulator `Java` env variable to run the emulator package:  https://source.corp.google.com/piper///depot/google3/java/com/google/cloud/datastore/emulator/opensource/cloud_datastore_emulator;l=30. This PR introduced some changes to the testing and building files to export `Java` env vars with Java 11 path from Java8 containers so the tests can run successfully on Java8 environment. This is made possible because Java_11 is also installed on Java8 docker file: https://github.com/googleapis/testing-infra-docker/blob/main/java/java8/Dockerfile#L107

