### PR TITLE
feat: Improve upon the default gRPC Connection Pool size

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,21 +59,11 @@ jobs:
         env:
           JOB_TYPE: test
   windows:
-    # Building using Java 8 and run the tests with Java 11 runtime
     runs-on: windows-latest
     steps:
     - name: Support longpaths
       run: git config --system core.longpaths true
     - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
-      with:
-        java-version: 11
-        distribution: temurin
-    - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
-      # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
-      # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
-      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
-      shell: bash
     - uses: actions/setup-java@v4
       with:
         distribution: temurin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,11 +59,21 @@ jobs:
         env:
           JOB_TYPE: test
   windows:
+    # Building using Java 8 and run the tests with Java 11 runtime
     runs-on: windows-latest
     steps:
     - name: Support longpaths
       run: git config --system core.longpaths true
     - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        java-version: 11
+        distribution: temurin
+    - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
+      # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
+      # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
+      run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
+      shell: bash
     - uses: actions/setup-java@v4
       with:
         distribution: temurin

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -223,9 +223,13 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
           builder.channelProvider != null
               ? builder.channelProvider
               : GrpcTransportOptions.setUpChannelProvider(
-                  DatastoreSettings.defaultGrpcTransportProviderBuilder().setChannelPoolSettings(
-                      ChannelPoolSettings.builder().setMinChannelCount(1).setInitialChannelCount(4)
-                          .build()), this);
+                  DatastoreSettings.defaultGrpcTransportProviderBuilder()
+                      .setChannelPoolSettings(
+                          ChannelPoolSettings.builder()
+                              .setMinChannelCount(1)
+                              .setInitialChannelCount(4)
+                              .build()),
+                  this);
     }
   }
 

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -219,7 +219,8 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
       throw new IllegalArgumentException(
           "Only gRPC transport allows setting of channel provider or credentials provider");
     } else if (getTransportOptions() instanceof GrpcTransportOptions) {
-      // For grpc transport options, configure default gRPC Connection pool with minChannelCount = 1 and maxChannelCount = 4
+      // For grpc transport options, configure default gRPC Connection pool with minChannelCount = 1
+      // and maxChannelCount = 4
       this.channelProvider =
           builder.channelProvider != null
               ? builder.channelProvider

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -51,6 +51,9 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
   private static final String DEFAULT_DATABASE_ID = "";
   public static final String PROJECT_ID_ENV_VAR = "DATASTORE_PROJECT_ID";
   public static final String LOCAL_HOST_ENV_VAR = "DATASTORE_EMULATOR_HOST";
+  public static final int INIT_CHANNEL_COUNT = 1;
+  public static final int MIN_CHANNEL_COUNT = 1;
+  public static final int MAX_CHANNEL_COUNT = 4;
 
   private transient TransportChannelProvider channelProvider = null;
 
@@ -228,8 +231,9 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
                   DatastoreSettings.defaultGrpcTransportProviderBuilder()
                       .setChannelPoolSettings(
                           ChannelPoolSettings.builder()
-                              .setMinChannelCount(1)
-                              .setMaxChannelCount(4)
+                              .setInitialChannelCount(INIT_CHANNEL_COUNT)
+                              .setMinChannelCount(MIN_CHANNEL_COUNT)
+                              .setMaxChannelCount(MAX_CHANNEL_COUNT)
                               .build()),
                   this);
     }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -219,6 +219,7 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
       throw new IllegalArgumentException(
           "Only gRPC transport allows setting of channel provider or credentials provider");
     } else if (getTransportOptions() instanceof GrpcTransportOptions) {
+      // For grpc transport options, configure default gRPC Connection pool with minChannelCount = 1 and maxChannelCount = 4
       this.channelProvider =
           builder.channelProvider != null
               ? builder.channelProvider
@@ -227,7 +228,7 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
                       .setChannelPoolSettings(
                           ChannelPoolSettings.builder()
                               .setMinChannelCount(1)
-                              .setInitialChannelCount(4)
+                              .setMaxChannelCount(4)
                               .build()),
                   this);
     }

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/DatastoreOptions.java
@@ -19,6 +19,7 @@ package com.google.cloud.datastore;
 import static com.google.cloud.datastore.Validator.validateNamespace;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.grpc.ChannelPoolSettings;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.ServiceDefaults;
@@ -222,7 +223,9 @@ public class DatastoreOptions extends ServiceOptions<Datastore, DatastoreOptions
           builder.channelProvider != null
               ? builder.channelProvider
               : GrpcTransportOptions.setUpChannelProvider(
-                  DatastoreSettings.defaultGrpcTransportProviderBuilder(), this);
+                  DatastoreSettings.defaultGrpcTransportProviderBuilder().setChannelPoolSettings(
+                      ChannelPoolSettings.builder().setMinChannelCount(1).setInitialChannelCount(4)
+                          .build()), this);
     }
   }
 

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/GrpcDatastoreRpc.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/GrpcDatastoreRpc.java
@@ -78,12 +78,14 @@ public class GrpcDatastoreRpc implements DatastoreRpc {
       DatastoreStubSettings datastoreStubSettings =
           DatastoreStubSettings.newBuilder(clientContext)
               .applyToAllUnaryMethods(retrySettingSetter(datastoreOptions))
-              .setTransportChannelProvider(DatastoreSettings.defaultGrpcTransportProviderBuilder()
-                  .setChannelPoolSettings(ChannelPoolSettings.builder()
-                      .setMinChannelCount(1)
-                      .setMaxChannelCount(4)
+              .setTransportChannelProvider(
+                  DatastoreSettings.defaultGrpcTransportProviderBuilder()
+                      .setChannelPoolSettings(
+                          ChannelPoolSettings.builder()
+                              .setMinChannelCount(1)
+                              .setMaxChannelCount(4)
+                              .build())
                       .build())
-                  .build())
               .build();
       datastoreStub = GrpcDatastoreStub.create(datastoreStubSettings);
     } catch (IOException e) {

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/GrpcDatastoreRpc.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/GrpcDatastoreRpc.java
@@ -83,8 +83,9 @@ public class GrpcDatastoreRpc implements DatastoreRpc {
                   DatastoreSettings.defaultGrpcTransportProviderBuilder()
                       .setChannelPoolSettings(
                           ChannelPoolSettings.builder()
-                              .setMinChannelCount(1)
-                              .setMaxChannelCount(4)
+                              .setInitialChannelCount(DatastoreOptions.INIT_CHANNEL_COUNT)
+                              .setMinChannelCount(DatastoreOptions.MIN_CHANNEL_COUNT)
+                              .setMaxChannelCount(DatastoreOptions.MAX_CHANNEL_COUNT)
                               .build())
                       .build())
               .build();

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/GrpcDatastoreRpc.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/GrpcDatastoreRpc.java
@@ -75,6 +75,7 @@ public class GrpcDatastoreRpc implements DatastoreRpc {
               ? getClientContextForEmulator(datastoreOptions)
               : getClientContext(datastoreOptions);
 
+      /* For grpc transport options, configure default gRPC Connection pool with minChannelCount = 1 and maxChannelCount = 4 */
       DatastoreStubSettings datastoreStubSettings =
           DatastoreStubSettings.newBuilder(clientContext)
               .applyToAllUnaryMethods(retrySettingSetter(datastoreOptions))

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/GrpcDatastoreRpc.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/GrpcDatastoreRpc.java
@@ -75,7 +75,6 @@ public class GrpcDatastoreRpc implements DatastoreRpc {
               ? getClientContextForEmulator(datastoreOptions)
               : getClientContext(datastoreOptions);
 
-      //
       DatastoreStubSettings datastoreStubSettings =
           DatastoreStubSettings.newBuilder(clientContext)
               .applyToAllUnaryMethods(retrySettingSetter(datastoreOptions))

--- a/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/GrpcDatastoreRpc.java
+++ b/google-cloud-datastore/src/main/java/com/google/cloud/datastore/spi/v1/GrpcDatastoreRpc.java
@@ -24,6 +24,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.GaxProperties;
+import com.google.api.gax.grpc.ChannelPoolSettings;
 import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.ClientContext;
@@ -74,9 +75,16 @@ public class GrpcDatastoreRpc implements DatastoreRpc {
               ? getClientContextForEmulator(datastoreOptions)
               : getClientContext(datastoreOptions);
 
+      //
       DatastoreStubSettings datastoreStubSettings =
           DatastoreStubSettings.newBuilder(clientContext)
               .applyToAllUnaryMethods(retrySettingSetter(datastoreOptions))
+              .setTransportChannelProvider(DatastoreSettings.defaultGrpcTransportProviderBuilder()
+                  .setChannelPoolSettings(ChannelPoolSettings.builder()
+                      .setMinChannelCount(1)
+                      .setMaxChannelCount(4)
+                      .build())
+                  .build())
               .build();
       datastoreStub = GrpcDatastoreStub.create(datastoreStubSettings);
     } catch (IOException e) {

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
@@ -117,9 +117,9 @@ public class DatastoreOptionsTest {
     ChannelPoolSettings channelPoolSettings =
         ((InstantiatingGrpcChannelProvider) datastoreOptions.getTransportChannelProvider())
             .getChannelPoolSettings();
-    assertEquals(channelPoolSettings.getInitialChannelCount(), 1);
-    assertEquals(channelPoolSettings.getMinChannelCount(), 1);
-    assertEquals(channelPoolSettings.getMaxChannelCount(), 4);
+    assertEquals(channelPoolSettings.getInitialChannelCount(), DatastoreOptions.INIT_CHANNEL_COUNT);
+    assertEquals(channelPoolSettings.getMinChannelCount(), DatastoreOptions.MIN_CHANNEL_COUNT);
+    assertEquals(channelPoolSettings.getMaxChannelCount(), DatastoreOptions.MAX_CHANNEL_COUNT);
   }
 
   @Test

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
@@ -114,7 +114,9 @@ public class DatastoreOptionsTest {
             .setCredentials(NoCredentials.getInstance())
             .setHost("http://localhost:" + PORT)
             .build();
-    ChannelPoolSettings channelPoolSettings = ((InstantiatingGrpcChannelProvider) datastoreOptions.getTransportChannelProvider()).getChannelPoolSettings();
+    ChannelPoolSettings channelPoolSettings =
+        ((InstantiatingGrpcChannelProvider) datastoreOptions.getTransportChannelProvider())
+            .getChannelPoolSettings();
     assertEquals(channelPoolSettings.getInitialChannelCount(), 1);
     assertEquals(channelPoolSettings.getMinChannelCount(), 1);
     assertEquals(channelPoolSettings.getMaxChannelCount(), 4);

--- a/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
+++ b/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
@@ -104,6 +104,23 @@ public class DatastoreOptionsTest {
   }
 
   @Test
+  public void testGrpcDefaultChannelConfigurations() {
+    DatastoreOptions datastoreOptions =
+        DatastoreOptions.newBuilder()
+            .setServiceRpcFactory(datastoreRpcFactory)
+            .setProjectId(PROJECT_ID)
+            .setDatabaseId(DATABASE_ID)
+            .setTransportOptions(GrpcTransportOptions.newBuilder().build())
+            .setCredentials(NoCredentials.getInstance())
+            .setHost("http://localhost:" + PORT)
+            .build();
+    ChannelPoolSettings channelPoolSettings = ((InstantiatingGrpcChannelProvider) datastoreOptions.getTransportChannelProvider()).getChannelPoolSettings();
+    assertEquals(channelPoolSettings.getInitialChannelCount(), 1);
+    assertEquals(channelPoolSettings.getMinChannelCount(), 1);
+    assertEquals(channelPoolSettings.getMaxChannelCount(), 4);
+  }
+
+  @Test
   public void testCustomChannelAndCredentials() {
     InstantiatingGrpcChannelProvider channelProvider =
         DatastoreSettings.defaultGrpcTransportProviderBuilder()


### PR DESCRIPTION
The current Java SDK uses a default gRPC connection pool with only [ one channel ](https://github.com/googleapis/sdk-platform-java/blob/816b1608e52543b4b5ade40056c89740fe35a459/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java#L627). This can cause performance issues for clients with high request rates (over 100 queries per second) because they may experience throttling.

To address this, this PR update proposes changing the default connection pool settings to allow for multiple channels (minimum 1, maximum 4). This should improve performance for clients with high request rates, without requiring any changes to their code. Customers can still customize the connection pool settings if needed.


Please refer here for more details: 
[configure a more reasonable default grpc connection pool config](https://b.corp.google.com/issues/378924444)
