### PR TITLE
feat: Java datastore gapic upgrade 

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -111,32 +111,7 @@ custom_content: |
   In this feature launch, the [Java Datastore client](https://github.com/googleapis/java-datastore) now offers gRPC as a transport layer option with experimental support. Using [gRPC connection pooling](https://grpc.io/docs/guides/performance/) enables distributing RPCs over multiple connections which may improve performance.
   
   #### Installation Instructions
-  The client can be built from the `grpc-experimental` branch on GitHub. For private preview, you can also download the artifact with the instructions provided below.
-
-  1. Download the datastore private preview package with dependencies:
-    ```
-    curl -o <path-to-downloaded-jar>  https://datastore-sdk-feature-release.web.app/google-cloud-datastore-2.20.0-grpc-experimental-1-SNAPSHOT-jar-with-dependencies.jar
-    ```
-  2. Run the following commands to install JDK locally:
-    ```
-    mvn install:install-file -Dfile=<path-to-downloaded-jar> -DgroupId=com.google.cloud -DartifactId=google-cloud-datastore -Dversion=2.20.0-grpc
-    ```
-  3. Edit your pom.xml to add above package to `<dependencies/>` section:
-    ```xml
-    <dependency>
-    <groupId>com.google.cloud</groupId>
-    <artifactId>google-cloud-datastore</artifactId>
-    <version>2.20.0-grpc-experimental-1-SNAPSHOT</version>
-    </dependency>
-    ```
-  
-  And if you have not yet, add below to `<repositories/>` section:
-    ```xml
-    <repository>
-    <id>local-repo</id>
-    <url>file://${user.home}/.m2/repository</url>
-    </repository>
-    ```
+  You'll need to obtain and install the latest google-cloud-datastore SDK.
   
   #### How to Use
   To opt-in to the gRPC transport behavior, simply add the below line of code (`setTransportOptions`) to your Datastore client instantiation.


### PR DESCRIPTION
This PR is to merge Java-datastore gapic upgrade feature branch `grpc-experimental-main` to main branch for public preview release.The goal is to upgrade the existing Google Cloud Datastore Java SDK to use GAPIC generated stubs as the transport, replacing the existing proto-over-http transport.

During public preview, while HTTP is the default, regapic support enables customers to effortlessly choose gRPC via simple code configuration.