### PR TITLE
build: disable errorprone for JDK 24+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,9 +233,30 @@
 
   <profiles>
     <profile>
+      <!-- the current errorprone version does not support JDK 24 onwards -->
+      <id>no-errorprone-jdk-24-onwards</id>
+      <activation>
+        <jdk>[24,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.children="append">
+                <!-- we only use the basic compilation flags without activating errorprone -->
+                <arg>-XDcompilePolicy=simple</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>java9</id>
       <activation>
-        <jdk>[9,)</jdk>
+        <jdk>[9,24)</jdk>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
The current errorprone version is not compatible with JDK 24 onwards. While we dont have a long term solution, we will disable the check for JDK 24.
