### PR TITLE
chore: manual update of update_generation_config.sh

### DIFF
--- a/.github/workflows/update_generation_config.yaml
+++ b/.github/workflows/update_generation_config.yaml
@@ -18,7 +18,6 @@ on:
   schedule:
   - cron: '0 2 * * *'
   workflow_dispatch:
-
 jobs:
   update-generation-config:
     runs-on: ubuntu-24.04
@@ -30,6 +29,9 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
+    - name: Install Dependencies
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y libxml2-utils
     - name: Update params in generation config to latest
       shell: bash
       run: |
@@ -41,4 +43,3 @@ jobs:
           --repo ${{ github.repository }}
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
-


### PR DESCRIPTION
Unfortunately, https://github.com/googleapis/sdk-platform-java/pull/3853 cannot be automatically propagated.

This PR manually updates this script with the latest.

Confirmation in https://github.com/googleapis/java-datastore/actions/runs/16505814105