### PR TITLE
deps: Manage Opentelemetry version from Shared-Deps

### DIFF
--- a/google-cloud-datastore/pom.xml
+++ b/google-cloud-datastore/pom.xml
@@ -16,7 +16,6 @@
   </parent>
   <properties>
     <site.installationModule>google-cloud-datastore</site.installationModule>
-    <opentelemetry.version>1.52.0</opentelemetry.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -140,12 +139,10 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
-      <version>${opentelemetry.version}</version>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-context</artifactId>
-      <version>${opentelemetry.version}</version>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>
@@ -211,25 +208,21 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk</artifactId>
-      <version>${opentelemetry.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-common</artifactId>
-      <version>${opentelemetry.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-testing</artifactId>
-      <version>${opentelemetry.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-trace</artifactId>
-      <version>${opentelemetry.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/google-cloud-datastore/pom.xml
+++ b/google-cloud-datastore/pom.xml
@@ -16,7 +16,7 @@
   </parent>
   <properties>
     <site.installationModule>google-cloud-datastore</site.installationModule>
-    <opentelemetry.version>1.42.1</opentelemetry.version>
+    <opentelemetry.version>1.52.0</opentelemetry.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Follow up from https://github.com/googleapis/sdk-platform-java/pull/3979, which bumps the shared opentelemetry version. 
If we were to merge the next sdk-platform-java-config without this change, we would get:

```
Error:  Errors: 
Error:    EnabledTraceUtilTest.globalOpenTelemetryRegistersGrpcChannelConfigurator:101 » NoClassDefFound io/opentelemetry/sdk/internal/ExceptionAttributeResolver
Error:    EnabledTraceUtilTest.openTelemetryInstanceRegistersGrpcChannelConfigurator:85 » NoClassDefFound io/opentelemetry/sdk/internal/ExceptionAttributeResolver
Error:    EnabledTraceUtilTest.usesGlobalOpenTelemetryIfOpenTelemetryInstanceNotProvided:68 » NoClassDefFound io/opentelemetry/sdk/internal/ExceptionAttributeResolver
Error:    EnabledTraceUtilTest.usesOpenTelemetryFromOptions:53 » NoClassDefFound io/opentelemetry/sdk/internal/ExceptionAttributeResolver
```

By removing this property and its references, all tests passed using a local snapshot of https://github.com/googleapis/sdk-platform-java/pull/3979.